### PR TITLE
Add edge margin to cookie preferences modal on mobile

### DIFF
--- a/components/consent/cookie-consent.tsx
+++ b/components/consent/cookie-consent.tsx
@@ -195,7 +195,7 @@ export function CookieConsent() {
       )}
 
       <Dialog open={showSettings} onOpenChange={(open) => (open ? openSettings() : closeSettings())}>
-        <DialogContent className="w-[calc(100%-2rem)] max-w-lg rounded-lg sm:max-w-lg">
+        <DialogContent className="w-[calc(100%-2rem)] max-w-lg rounded-lg p-6 sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>{copy.settingsTitle}</DialogTitle>
             <DialogDescription>{copy.settingsBody}</DialogDescription>

--- a/components/consent/cookie-consent.tsx
+++ b/components/consent/cookie-consent.tsx
@@ -195,7 +195,7 @@ export function CookieConsent() {
       )}
 
       <Dialog open={showSettings} onOpenChange={(open) => (open ? openSettings() : closeSettings())}>
-        <DialogContent className="sm:max-w-lg">
+        <DialogContent className="w-[calc(100%-2rem)] max-w-lg rounded-lg sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>{copy.settingsTitle}</DialogTitle>
             <DialogDescription>{copy.settingsBody}</DialogDescription>


### PR DESCRIPTION
## Summary
- The "Cookie 偏好設定" settings dialog (opened via the footer's "Cookie 設定" link) previously rendered flush with the viewport edges on mobile — no side margin and square corners.
- `DialogContent` in `components/consent/cookie-consent.tsx` now gets a `calc(100% - 2rem)` width and `rounded-lg`, giving it consistent breathing room from the screen edges at all breakpoints instead of touching them edge-to-edge.

## Test plan
- [x] Ran the dev server and opened the cookie preferences dialog at a 390×844 mobile viewport via Playwright — confirmed the modal now has visible left/right margin and rounded corners instead of spanning full width.
- [ ] Manual check across breakpoints / browsers in review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GwF4AQSSx8TQ4M3PCs4Myq)_