### PR TITLE
fix: pin cobe to 0.6.3 — production is down on globe.toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",
-    "cobe": "latest",
+    "cobe": "0.6.3",
     "date-fns": "3.6.0",
     "embla-carousel-react": "8.5.1",
     "fast-xml-parser": "^5.5.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,8 +135,8 @@ importers:
         specifier: 1.0.4
         version: 1.0.4(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       cobe:
-        specifier: latest
-        version: 2.0.1
+        specifier: 0.6.3
+        version: 0.6.3
       date-fns:
         specifier: 3.6.0
         version: 3.6.0
@@ -1971,8 +1971,8 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
-  cobe@2.0.1:
-    resolution: {integrity: sha512-aaa6vcIlaC8C1SF50LDH0Anybo/EAXnrxqe+bwvr4+YUtZydqjeBjTTD7ziCCkbRrRGSns3I3F6cZsf3W+L+ag==}
+  cobe@0.6.3:
+    resolution: {integrity: sha512-WHr7X4o1ym94GZ96h7b1pNemZJacbOzd02dZtnVwuC4oWBaLg96PBmp2rIS1SAhUDhhC/QyS9WEqkpZIs/ZBTg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2643,6 +2643,9 @@ packages:
 
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
+  phenomenon@1.6.0:
+    resolution: {integrity: sha512-7h9/fjPD3qNlgggzm88cY58l9sudZ6Ey+UmZsizfhtawO6E3srZQXywaNm2lBwT72TbpHYRPy7ytIHeBUD/G0A==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4996,7 +4999,9 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  cobe@2.0.1: {}
+  cobe@0.6.3:
+    dependencies:
+      phenomenon: 1.6.0
 
   color-convert@2.0.1:
     dependencies:
@@ -5807,6 +5812,8 @@ snapshots:
 
   performance-now@2.1.0:
     optional: true
+
+  phenomenon@1.6.0: {}
 
   picocolors@1.1.1: {}
 


### PR DESCRIPTION
## Production is currently broken; this fixes it

tecxmate.com renders "Something went wrong!" on every page load:

```
TypeError: I.toggle is not a function. (In 'I.toggle(!1)', 'I.toggle' is undefined)
```

That is `globe.toggle(false)` at `components/globe-background.tsx:217`.

## Cause

`package.json` declared `"cobe": "latest"`. The old `pnpm-lock.yaml` had it locked at **0.6.3**, but regenerating that lockfile (941af12, in #8) re-resolved `latest` to **cobe 2.0.1**.

| | cobe 0.6.3 | cobe 2.0.1 |
|---|---|---|
| dependencies | `phenomenon ^1.6.0` | **none** |
| `toggle()` / `shouldRender` / `render()` | yes, via phenomenon | **gone** |

`globe-background.tsx` is written against the 0.6.x phenomenon API, so under 2.0.1 the call throws on mount and the error boundary takes over the page.

This was a self-inflicted regression from my lockfile fix — that fix was needed (production could not build at all before it), but it re-resolved an unpinned dependency as a side effect.

## Fix

Pin `cobe` to exactly `0.6.3` — the version `package-lock.json` already used — so npm and pnpm installs agree, and regenerate the pnpm lock entry.

## Verification

Clean `pnpm install --frozen-lockfile` in a scratch dir:

- `cobe` → 0.6.3
- `phenomenon` → 1.6.0, resolvable from cobe
- `prototype.toggle` present in `phenomenon.mjs`

`npm run build` passes.

## Follow-up worth considering

`"latest"` as a version specifier is the underlying hazard — any lockfile regeneration can silently pull a breaking major. Worth auditing `package.json` for others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)