### PR TITLE
Blog category tabs, plus fixes to category and language resolution

### DIFF
--- a/app/lang/en.json
+++ b/app/lang/en.json
@@ -53,5 +53,9 @@
   "visit_project": "Visit Project",
   "news_insights_subtitle": "Stay updated with the latest trends and insights from our technology experts.",
   "view_all_posts": "View all posts",
-  "read_full_article": "Read Full Article"
+  "read_full_article": "Read Full Article",
+  "blog_tab_industry_news": "Industry News",
+  "blog_tab_our_products": "Our Products",
+  "blog_tab_tecxmate_news": "Tecxmate News",
+  "blog_tab_empty": "No posts in this category yet."
 }

--- a/app/lang/en.json
+++ b/app/lang/en.json
@@ -56,6 +56,6 @@
   "read_full_article": "Read Full Article",
   "blog_tab_industry_news": "Industry News",
   "blog_tab_our_products": "Our Products",
-  "blog_tab_tecxmate_news": "Tecxmate News",
+  "blog_tab_our_stories": "Our Stories",
   "blog_tab_empty": "No posts in this category yet."
 }

--- a/app/lang/vi.json
+++ b/app/lang/vi.json
@@ -53,5 +53,9 @@
   "visit_project": "Truy cập dự án",
   "news_insights_subtitle": "Cập nhật những xu hướng và thông tin mới nhất từ các chuyên gia công nghệ của chúng tôi.",
   "view_all_posts": "Xem tất cả bài viết",
-  "read_full_article": "Đọc bài viết đầy đủ"
+  "read_full_article": "Đọc bài viết đầy đủ",
+  "blog_tab_industry_news": "Tin ngành",
+  "blog_tab_our_products": "Sản phẩm của chúng tôi",
+  "blog_tab_tecxmate_news": "Tin Tecxmate",
+  "blog_tab_empty": "Chưa có bài viết trong danh mục này."
 }

--- a/app/lang/vi.json
+++ b/app/lang/vi.json
@@ -56,6 +56,6 @@
   "read_full_article": "Đọc bài viết đầy đủ",
   "blog_tab_industry_news": "Tin ngành",
   "blog_tab_our_products": "Sản phẩm của chúng tôi",
-  "blog_tab_tecxmate_news": "Tin Tecxmate",
+  "blog_tab_our_stories": "Câu chuyện của chúng tôi",
   "blog_tab_empty": "Chưa có bài viết trong danh mục này."
 }

--- a/app/lang/zh.json
+++ b/app/lang/zh.json
@@ -53,5 +53,9 @@
   "visit_project": "造訪專案",
   "news_insights_subtitle": "掌握技術專家的最新趨勢分析與洞察。",
   "view_all_posts": "查看所有文章",
-  "read_full_article": "閱讀全文"
+  "read_full_article": "閱讀全文",
+  "blog_tab_industry_news": "產業新聞",
+  "blog_tab_our_products": "產品動態",
+  "blog_tab_tecxmate_news": "Tecxmate 消息",
+  "blog_tab_empty": "此分類尚無文章。"
 }

--- a/app/lang/zh.json
+++ b/app/lang/zh.json
@@ -56,6 +56,6 @@
   "read_full_article": "閱讀全文",
   "blog_tab_industry_news": "產業新聞",
   "blog_tab_our_products": "產品動態",
-  "blog_tab_tecxmate_news": "Tecxmate 消息",
+  "blog_tab_our_stories": "我們的故事",
   "blog_tab_empty": "此分類尚無文章。"
 }

--- a/components/campaigns-section.tsx
+++ b/components/campaigns-section.tsx
@@ -1,14 +1,20 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { Calendar, ArrowRight, Clock } from "lucide-react"
 import Link from "next/link"
 import { useLanguage } from "@/components/language-provider"
+import { BLOG_CATEGORY_TABS, postsForTab, type BlogCategoryTabId } from "@/lib/blog-categories"
 import type { WPBlogPost as BlogPost } from "@/lib/wordpress"
+
+/** Posts shown per tab before the visitor is sent to the full blog listing. */
+const POSTS_PER_TAB = 3
 
 export function CampaignsSection() {
   const [posts, setPosts] = useState<BlogPost[]>([])
   const [loading, setLoading] = useState(true)
+  // null until the visitor picks a tab, so the default can follow the data.
+  const [selectedTabId, setSelectedTabId] = useState<BlogCategoryTabId | null>(null)
   const { language, t } = useLanguage()
 
   useEffect(() => {
@@ -20,7 +26,7 @@ export function CampaignsSection() {
         if (!response.ok) throw new Error(`Failed: ${response.status}`)
         const data = await response.json()
         if (mounted) {
-          setPosts(data.slice(0, 3)) // Show top 3 recent posts
+          setPosts(data)
           setLoading(false)
         }
       } catch (err) {
@@ -37,6 +43,21 @@ export function CampaignsSection() {
     return () => { mounted = false }
   }, [language])
 
+  // One bucket per tab, computed once so the tab bar can show counts and the
+  // default tab can skip over categories that have nothing published yet.
+  const postsByTab = useMemo(
+    () =>
+      BLOG_CATEGORY_TABS.map((tab) => ({
+        tab,
+        posts: postsForTab(posts, tab).slice(0, POSTS_PER_TAB),
+      })),
+    [posts],
+  )
+
+  const activeTabId =
+    selectedTabId ?? postsByTab.find((entry) => entry.posts.length > 0)?.tab.id ?? BLOG_CATEGORY_TABS[0].id
+  const activePosts = postsByTab.find((entry) => entry.tab.id === activeTabId)?.posts ?? []
+
   if (loading) {
     return (
       <section id="campaigns" className="bg-muted py-24 md:py-28 lg:py-32">
@@ -47,7 +68,9 @@ export function CampaignsSection() {
     )
   }
 
-  if (posts.length === 0) return null
+  // Nothing categorised into any of the three tabs — hide the section entirely
+  // rather than render an empty shell.
+  if (postsByTab.every((entry) => entry.posts.length === 0)) return null
 
   return (
     <section id="campaigns" className="bg-muted py-24 md:py-28 lg:py-32">
@@ -70,8 +93,47 @@ export function CampaignsSection() {
           </Link>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {posts.map((post) => (
+        <div
+          role="tablist"
+          aria-label={t("news_insights")}
+          className="flex flex-wrap gap-2 border-b border-border mb-10"
+        >
+          {postsByTab.map(({ tab, posts: tabPosts }) => {
+            const isActive = tab.id === activeTabId
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                id={`campaigns-tab-${tab.id}`}
+                aria-selected={isActive}
+                aria-controls={`campaigns-panel-${tab.id}`}
+                onClick={() => setSelectedTabId(tab.id)}
+                className={`-mb-px border-b-2 px-4 py-3 text-sm font-semibold tracking-wide transition-colors ${
+                  isActive
+                    ? "border-primary text-primary"
+                    : "border-transparent text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                <span suppressHydrationWarning>{t(tab.labelKey)}</span>
+                <span className="ml-2 text-xs font-normal text-muted-foreground">{tabPosts.length}</span>
+              </button>
+            )
+          })}
+        </div>
+
+        <div
+          role="tabpanel"
+          id={`campaigns-panel-${activeTabId}`}
+          aria-labelledby={`campaigns-tab-${activeTabId}`}
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"
+        >
+          {activePosts.length === 0 && (
+            <p className="text-muted-foreground md:col-span-2 lg:col-span-3" suppressHydrationWarning>
+              {t("blog_tab_empty")}
+            </p>
+          )}
+          {activePosts.map((post) => (
             <Link
               key={post.id}
               href={`/blog/${post.slug}`}

--- a/docs/AI_NEWS_AND_SOCIAL_AUTOMATION.md
+++ b/docs/AI_NEWS_AND_SOCIAL_AUTOMATION.md
@@ -97,7 +97,9 @@ replace the manual blog workflow unless `BLOG_SOURCE=local` is set.
 Generated news entries use:
 
 - `source: ai-news-agent`
-- `category: Automated News`
+- `category: Industry News` (so briefs land in the homepage Industry News tab;
+  older briefs still carry the previous `Automated News` name and are matched by
+  an alias in `lib/blog-categories.ts`)
 - `language: en`, `language: zh`, or `language: vi`
 - Slugs starting with `ai-industry-brief-YYYY-MM-DD-language-`
 

--- a/lib/ai-news-agent.ts
+++ b/lib/ai-news-agent.ts
@@ -1,5 +1,6 @@
 import { XMLParser } from "fast-xml-parser"
 import { z } from "zod"
+import { AUTOMATED_NEWS_CATEGORY } from "./blog-categories"
 import type { StoredBlogPost } from "./blog-store"
 
 type NewsSource = {
@@ -439,7 +440,7 @@ export function assembleDailyPost(
     publishedAt: now.toISOString(),
     updatedAt: now.toISOString(),
     readTime: estimateReadTime(content),
-    category: "Automated News",
+    category: AUTOMATED_NEWS_CATEGORY,
     coverImage: generated.coverImage?.trim() || "/graphics/Strategy & Research.png",
     content,
     tags: Array.from(new Set(["AI", "Startups", "Industry", languageTag(language), ...generated.tags])),

--- a/lib/blog-categories.ts
+++ b/lib/blog-categories.ts
@@ -7,10 +7,19 @@ import type { WPBlogPost } from "./wordpress"
  * WordPress. Posts in any other category are not surfaced on the homepage.
  */
 export const BLOG_CATEGORY_TABS = [
-  { id: "industry-news", wpCategory: "Industry News", labelKey: "blog_tab_industry_news" },
-  { id: "our-products", wpCategory: "Our Products", labelKey: "blog_tab_our_products" },
-  { id: "tecxmate-news", wpCategory: "Tecxmate News", labelKey: "blog_tab_tecxmate_news" },
+  {
+    id: "industry-news",
+    wpCategory: "Industry News",
+    labelKey: "blog_tab_industry_news",
+    // Briefs published before the rename still carry the old category name.
+    aliases: ["Automated News"],
+  },
+  { id: "our-products", wpCategory: "Our Products", labelKey: "blog_tab_our_products", aliases: [] },
+  { id: "our-stories", wpCategory: "Our Stories", labelKey: "blog_tab_our_stories", aliases: ["Tecxmate News"] },
 ] as const
+
+/** Category the RSS+LLM news agent files its daily briefs under. */
+export const AUTOMATED_NEWS_CATEGORY = BLOG_CATEGORY_TABS[0].wpCategory
 
 export type BlogCategoryTab = (typeof BLOG_CATEGORY_TABS)[number]
 export type BlogCategoryTabId = BlogCategoryTab["id"]
@@ -21,6 +30,6 @@ function normalize(value: string): string {
 }
 
 export function postsForTab(posts: readonly WPBlogPost[], tab: BlogCategoryTab): WPBlogPost[] {
-  const target = normalize(tab.wpCategory)
-  return posts.filter((post) => normalize(post.category || "") === target)
+  const accepted = new Set([tab.wpCategory, ...tab.aliases].map(normalize))
+  return posts.filter((post) => accepted.has(normalize(post.category || "")))
 }

--- a/lib/blog-categories.ts
+++ b/lib/blog-categories.ts
@@ -11,11 +11,27 @@ export const BLOG_CATEGORY_TABS = [
     id: "industry-news",
     wpCategory: "Industry News",
     labelKey: "blog_tab_industry_news",
-    // Briefs published before the rename still carry the old category name.
-    aliases: ["Automated News"],
+    // "News" is the category the WordPress blog already files industry pieces
+    // under; "Automated News" is what the agent used before the rename.
+    aliases: ["News", "Automated News"],
+    tags: [],
   },
-  { id: "our-products", wpCategory: "Our Products", labelKey: "blog_tab_our_products", aliases: [] },
-  { id: "our-stories", wpCategory: "Our Stories", labelKey: "blog_tab_our_stories", aliases: ["Tecxmate News"] },
+  {
+    id: "our-products",
+    wpCategory: "Our Products",
+    labelKey: "blog_tab_our_products",
+    aliases: [],
+    // Product write-ups (TECXWORK, TECXNOTE, Vietnamy) are marked by tag
+    // rather than by category.
+    tags: ["projects"],
+  },
+  {
+    id: "our-stories",
+    wpCategory: "Our Stories",
+    labelKey: "blog_tab_our_stories",
+    aliases: ["Tecxmate News"],
+    tags: [],
+  },
 ] as const
 
 /** Category the RSS+LLM news agent files its daily briefs under. */
@@ -30,6 +46,12 @@ function normalize(value: string): string {
 }
 
 export function postsForTab(posts: readonly WPBlogPost[], tab: BlogCategoryTab): WPBlogPost[] {
-  const accepted = new Set([tab.wpCategory, ...tab.aliases].map(normalize))
-  return posts.filter((post) => accepted.has(normalize(post.category || "")))
+  const categories = new Set([tab.wpCategory, ...tab.aliases].map(normalize))
+  const tags = new Set(tab.tags.map(normalize))
+
+  return posts.filter(
+    (post) =>
+      categories.has(normalize(post.category || "")) ||
+      (post.tags ?? []).some((tag) => tags.has(normalize(tag))),
+  )
 }

--- a/lib/blog-categories.ts
+++ b/lib/blog-categories.ts
@@ -1,0 +1,26 @@
+import type { WPBlogPost } from "./wordpress"
+
+/**
+ * The three categories the homepage blog section is split into. A post is
+ * shown under a tab only when its WordPress category matches that tab's
+ * `wpCategory` name — so these strings must exist verbatim as categories in
+ * WordPress. Posts in any other category are not surfaced on the homepage.
+ */
+export const BLOG_CATEGORY_TABS = [
+  { id: "industry-news", wpCategory: "Industry News", labelKey: "blog_tab_industry_news" },
+  { id: "our-products", wpCategory: "Our Products", labelKey: "blog_tab_our_products" },
+  { id: "tecxmate-news", wpCategory: "Tecxmate News", labelKey: "blog_tab_tecxmate_news" },
+] as const
+
+export type BlogCategoryTab = (typeof BLOG_CATEGORY_TABS)[number]
+export type BlogCategoryTabId = BlogCategoryTab["id"]
+
+/** Category names differ only by casing and stray spacing between WP installs. */
+function normalize(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+export function postsForTab(posts: readonly WPBlogPost[], tab: BlogCategoryTab): WPBlogPost[] {
+  const target = normalize(tab.wpCategory)
+  return posts.filter((post) => normalize(post.category || "") === target)
+}

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -64,9 +64,22 @@ function wpFeaturedImage(post: any) {
   return "/placeholder.svg?height=200&width=400"
 }
 
+/**
+ * Categories in WordPress double as language and housekeeping markers
+ * ("en", "vn", "lang", "Non"), and they sort ahead of the topical one — so a
+ * post filed under "Our Stories" reports its category as "en" if we just take
+ * the first term. Skip the markers and return the first real topic.
+ */
+const NON_TOPICAL_CATEGORIES = new Set(["en", "vn", "vi", "zh", "lang", "non", "uncategorized"])
+
 function wpPrimaryCategory(post: any) {
-  const cat = post._embedded?.["wp:term"]?.[0]?.[0]
-  return cat?.name || "Uncategorized"
+  const categories: any[] = post._embedded?.["wp:term"]?.[0] || []
+  const names = categories
+    .map((cat) => String(cat?.name || "").trim())
+    .filter((name) => name.length > 0)
+
+  const topical = names.find((name) => !NON_TOPICAL_CATEGORIES.has(name.toLowerCase()))
+  return topical || names[0] || "Uncategorized"
 }
 
 function wpTags(post: any): string[] {

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -87,10 +87,27 @@ function wpTags(post: any): string[] {
   return tags.map((tag: any) => tag.name || "").filter((name: string) => name.length > 0)
 }
 
-const languageToTagSlug: Record<string, string> = {
+const TERM_SLUG_TO_LANGUAGE: Record<string, string> = {
   en: "en",
-  vi: "vn",
+  vn: "vi",
+  vi: "vi",
   zh: "zh",
+  "zh-tw": "zh",
+}
+
+/**
+ * Language is marked with a tag (and, on older posts, a category) whose slug is
+ * en/vn/zh. A post carrying no marker is treated as English rather than dropped:
+ * forgetting the tag should put a post in the wrong language list, where it is
+ * visible and fixable, not remove it from the site with no trace.
+ */
+function wpPostLanguage(post: any): string {
+  const terms: any[] = (post._embedded?.["wp:term"] ?? []).flat()
+  for (const term of terms) {
+    const language = TERM_SLUG_TO_LANGUAGE[String(term?.slug || "").toLowerCase()]
+    if (language) return language
+  }
+  return "en"
 }
 
 function shouldShowAiNewsPosts(): boolean {
@@ -109,40 +126,15 @@ export async function wpGetAllPosts(language: string = "en"): Promise<WPBlogPost
     return storedPosts
   }
 
+  // Language is filtered below, in code, rather than by asking WordPress for a
+  // tag id: querying by tag makes an untagged post invisible everywhere.
+  const wantedLanguage = TERM_SLUG_TO_LANGUAGE[normalizedLanguage] || "en"
+
   try {
-    const tagSlug = languageToTagSlug[normalizedLanguage] || languageToTagSlug.en
-    let tagId: number | undefined
-
-    try {
-      const tagRes = await fetch(`${WORDPRESS_API_URL}/tags?slug=${encodeURIComponent(tagSlug)}`)
-
-      if (tagRes.ok) {
-        const tagData = await tagRes.json()
-        tagId = tagData?.[0]?.id
-
-        if (!tagId) {
-          console.warn("No WordPress tag found for language slug:", { language: normalizedLanguage, tagSlug })
-        }
-      } else {
-        console.warn("Failed to fetch WordPress tag for language:", {
-          language: normalizedLanguage,
-          tagSlug,
-          status: tagRes.status,
-          statusText: tagRes.statusText,
-        })
-      }
-    } catch (tagError) {
-      console.error("Error fetching WordPress tag:", { language: normalizedLanguage, tagSlug, error: tagError })
-    }
-
     const params = new URLSearchParams({
-      per_page: "20",
+      per_page: "100",
       _embed: "1",
     })
-
-    if (tagId) {
-      params.append("tags", String(tagId))
-    }
 
     const url = `${WORDPRESS_API_URL}/posts?${params.toString()}`
     console.log('🔍 Fetching WordPress posts from:', url)
@@ -180,7 +172,7 @@ export async function wpGetAllPosts(language: string = "en"): Promise<WPBlogPost
       return storedPosts
     }
     
-    const posts = data.map((p: any) => {
+    const posts = data.filter((p: any) => wpPostLanguage(p) === wantedLanguage).map((p: any) => {
       // Decode URL-encoded slugs (important for non-ASCII characters)
       let decodedSlug = p.slug
       try {


### PR DESCRIPTION
Splits the homepage blog section into three tabs and fixes two bugs in how posts are resolved from WordPress.

## Tabs

The "News & Insights" section now has **Industry News · Our Products · Our Stories**, up to 3 posts each. Tabs carry a post count, use proper `role="tablist"` / `aria-selected` wiring, and open on the first tab that has posts. If no post matches any tab, the section hides itself as before.

## Two bugs fixed

**Every post reported `category: "en"`.** WordPress categories double as language and housekeeping markers (`en`, `vn`, `lang`, `Non`) and sort ahead of the topical one, so taking the first term returned the language. The resolver now skips the markers and takes the first real topic. Without this, no post matches any tab and the section renders nothing.

**A post with no language tag was invisible everywhere.** `wpGetAllPosts` queried WordPress for posts carrying the language tag id, so an untagged post vanished from the homepage, `/blog`, the sitemap and the RSS feed with no trace. Language is now classified in code, defaulting to English when unmarked — a forgotten tag puts a post in the wrong list, where it is visible and fixable, instead of deleting it from the site.

This recovers **5 English posts** that were silently hidden: the TECXMATE origin story, all three product write-ups, and the Meta "vibe-coding" piece. English goes from 3 posts to 8.

## Also

- The AI news agent files briefs under `Industry News` instead of `Automated News`; legacy briefs are matched by alias.
- Tab labels added to en/vi/zh.

## Verification

- `tsc --noEmit` — no errors in any touched file (4 pre-existing errors elsewhere are untouched)
- `npm run build` — compiles
- Filtering checked against the **live** tecxmate.wordpress.com API across all 16 real posts: Industry News 8, Our Products 3, Our Stories 1, and en/vi split 8/8 with no leakage

## Notes for after merge

- 4 Vietnamese posts have only `lang`/`Non` categories and land in no tab; they need `News` added in WordPress.
- `Non` looks like a typo category sitting on 5 posts.
- Keep language markers as **tags** — a few posts are currently identified by an `en`/`vn` category, which the planned category cleanup would remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)