### PR TITLE
Mobile: snap through services one per screen; hold the hero still

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -376,6 +376,18 @@ html[data-idle] *::after {
   animation-play-state: paused !important;
 }
 
+/*
+ * Below lg the services are stacked one per screen and snap as you scroll.
+ * Proximity rather than mandatory: snap points exist only inside that one
+ * section, and mandatory would let a scroll anywhere else on the page get
+ * yanked toward them.
+ */
+@media (max-width: 1023.98px) {
+  html {
+    scroll-snap-type: y proximity;
+  }
+}
+
 /* Countdown line on the active service tab while the rail is auto-rotating. */
 @keyframes tab-progress {
   from { transform: scaleX(0); }

--- a/components/sales/proof-section.tsx
+++ b/components/sales/proof-section.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useLanguage } from "@/components/language-provider"
 import { salesDeck, pickLocale } from "@/lib/sales-deck"
 import type { Locale } from "@/lib/site-content"
@@ -78,7 +78,6 @@ export function ProofSection() {
   const [isDesktop, setIsDesktop] = useState(false)
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([])
   const sectionRef = useRef<HTMLElement | null>(null)
-  const trackRef = useRef<HTMLDivElement | null>(null)
 
   const offerings = proof.offerings
   const active: Offering = offerings[activeIndex]
@@ -129,53 +128,6 @@ export function ProofSection() {
     )
     return () => window.clearInterval(timer)
   }, [isAdvancing, offerings.length])
-
-  // Mobile: map scroll position within the pinned track onto a service.
-  useEffect(() => {
-    if (isDesktop) return
-    const track = trackRef.current
-    if (!track) return
-
-    let frame = 0
-    const update = () => {
-      frame = 0
-      const rect = track.getBoundingClientRect()
-      const scrollable = rect.height - window.innerHeight
-      if (scrollable <= 0) return
-
-      const progress = Math.min(Math.max(-rect.top / scrollable, 0), 1)
-      // The last step would only be reached at exactly 1, so clamp into range.
-      const index = Math.min(offerings.length - 1, Math.floor(progress * offerings.length))
-      setActiveIndex(index)
-    }
-
-    const onScroll = () => {
-      if (frame) return
-      frame = window.requestAnimationFrame(update)
-    }
-
-    update()
-    window.addEventListener("scroll", onScroll, { passive: true })
-    window.addEventListener("resize", onScroll)
-    return () => {
-      window.removeEventListener("scroll", onScroll)
-      window.removeEventListener("resize", onScroll)
-      if (frame) window.cancelAnimationFrame(frame)
-    }
-  }, [isDesktop, offerings.length])
-
-  /** Jump the page to the scroll offset that shows a given service. */
-  const scrollToOffering = useCallback(
-    (index: number) => {
-      const track = trackRef.current
-      if (!track) return
-      const scrollable = track.offsetHeight - window.innerHeight
-      const step = scrollable / offerings.length
-      // Land mid-step so the position is comfortably inside the target range.
-      window.scrollTo({ top: track.offsetTop + step * (index + 0.5), behavior: "smooth" })
-    },
-    [offerings.length],
-  )
 
   const selectTab = (index: number) => {
     setIsRotating(false)
@@ -281,39 +233,28 @@ export function ProofSection() {
         </div>
       </div>
 
-      {/* Mobile: the section pins and vertical scrolling steps through the services */}
-      <div
-        ref={trackRef}
-        className="lg:hidden relative"
-        style={{ height: `${offerings.length * 100}svh` }}
-      >
-        {/* No overflow-hidden: the tallest panel leaves only ~46px spare on a
-            small phone, and clipping would drop copy silently if a visitor
-            scales up their text. Overflowing visibly is the safer failure. */}
-        <div className="sticky top-0 flex h-[100svh] items-center">
-          <div className="container mx-auto px-4 w-full">
-            <div className="mb-6 flex items-center gap-3">
-              <div className="flex gap-1.5">
-                {offerings.map((offering, index) => (
-                  <button
-                    key={offering.id}
-                    type="button"
-                    onClick={() => scrollToOffering(index)}
-                    aria-label={pickLocale(offering.title, language)}
-                    aria-current={index === activeIndex}
-                    className={`h-1.5 rounded-full transition-all ${
-                      index === activeIndex ? "w-6 bg-primary" : "w-1.5 bg-border"
-                    }`}
-                  />
-                ))}
-              </div>
-              <p className="text-xs text-muted-foreground tabular-nums">
-                {activeIndex + 1} / {offerings.length}
+      {/*
+        Mobile: one service per screen, snapping as you scroll. Nothing is
+        pinned — a sticky panel fought iOS Safari's collapsing URL bar, which
+        resizes the viewport mid-scroll and made the pin jitter. Ordinary
+        blocks in normal flow have no such problem.
+      */}
+      <div className="lg:hidden">
+        {offerings.map((offering, index) => (
+          <div
+            key={offering.id}
+            // scroll-mt clears the fixed 4rem navbar, which would otherwise
+            // cover the top of each service as it snaps into place.
+            className="snap-start scroll-mt-16 flex min-h-[100svh] flex-col justify-center py-12"
+          >
+            <div className="container mx-auto px-4">
+              <p className="mb-4 text-xs text-muted-foreground tabular-nums">
+                {index + 1} / {offerings.length}
               </p>
+              <OfferingPanel offering={offering} language={language} />
             </div>
-            <OfferingPanel offering={active} language={language} />
           </div>
-        </div>
+        ))}
       </div>
     </section>
   )

--- a/components/shader-background.tsx
+++ b/components/shader-background.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 import { useTheme } from "next-themes"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { GlobeBackground } from "@/components/globe-background"
 import { Starfield } from "@/components/starfield"
 
@@ -12,52 +12,10 @@ interface ShaderBackgroundProps {
 
 export default function ShaderBackground({ children }: ShaderBackgroundProps) {
   const { resolvedTheme } = useTheme()
-  const mobilePatternRef = useRef<HTMLDivElement>(null)
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
     setMounted(true)
-  }, [])
-
-  useEffect(() => {
-    const pattern = mobilePatternRef.current
-    if (!pattern) return
-
-    const mobileMq = window.matchMedia("(max-width: 767px)")
-    let frame = 0
-
-    const update = () => {
-      frame = 0
-      if (!mobileMq.matches) {
-        pattern.style.transform = ""
-        return
-      }
-
-      const hero = document.getElementById("hero")
-      const top = hero?.getBoundingClientRect().top ?? 0
-      const height = hero?.offsetHeight || window.innerHeight
-      const progress = Math.max(0, Math.min(1, -top / height))
-      const offset = Math.max(-42, Math.min(42, -top * 0.12))
-      const spread = 1 + progress * 0.18
-      pattern.style.transform = `translate3d(0, ${offset}px, 0) scale(${spread})`
-    }
-
-    const requestUpdate = () => {
-      if (frame) return
-      frame = window.requestAnimationFrame(update)
-    }
-
-    update()
-    window.addEventListener("scroll", requestUpdate, { passive: true })
-    window.addEventListener("resize", requestUpdate)
-    mobileMq.addEventListener("change", requestUpdate)
-
-    return () => {
-      if (frame) window.cancelAnimationFrame(frame)
-      window.removeEventListener("scroll", requestUpdate)
-      window.removeEventListener("resize", requestUpdate)
-      mobileMq.removeEventListener("change", requestUpdate)
-    }
   }, [])
 
   const isDark = mounted && resolvedTheme === "dark"
@@ -100,11 +58,9 @@ export default function ShaderBackground({ children }: ShaderBackgroundProps) {
         }}
         aria-hidden
       />
-      <div
-        ref={mobilePatternRef}
-        className="absolute inset-0 z-[1] h-full w-full origin-center md:hidden pointer-events-none will-change-transform"
-        aria-hidden
-      >
+      {/* Static on mobile: this pattern used to translate and scale with scroll,
+          which read as drift behind the headline rather than depth. */}
+      <div className="absolute inset-0 z-[1] h-full w-full md:hidden pointer-events-none" aria-hidden>
         {tileClusters.map((cluster) => (
           <div
             key={cluster.id}


### PR DESCRIPTION
Replaces the pinned services panel on mobile, and stops the hero pattern moving on scroll.

## Services: pinned → snap

The sticky panel depended on a stable viewport height. iOS Safari's collapsing URL bar resizes the viewport mid-scroll, so the pin fought the browser instead of holding still.

The six services are now ordinary blocks, one viewport tall each, that snap as you scroll. No sticky positioning, no scroll listener, no index maths — the browser does the work.

Snap strictness is **proximity, not mandatory**: the snap points exist only inside this one section, and `mandatory` on the root scroller would let a scroll anywhere else on the page get yanked toward them. `scroll-margin-top: 64px` clears the fixed navbar.

## Hero: parallax removed on mobile

The mobile hero pattern translated and scaled against scroll position (`translate3d` + `scale`, driven by a scroll listener). It read as drift behind the headline rather than depth. Now static — which also removes a scroll listener from the most performance-sensitive part of the page.

## Verification (Chromium, 390×844)

- No horizontal overflow (390 vs 390)
- Six blocks, exactly 844px each
- `scroll-snap-align: start`, `scroll-margin-top: 64px`
- No sticky element rendered on mobile (the desktop rail is present but `display:none`)
- `scroll-snap-type` is active on mobile, `none` at 1440
- Hero pattern `transform` identical at scrollY 0 and 400 — provably still

**Not verified in Safari.** WebKit would not launch in my environment, so I could not test the engine this change is aimed at. The approach removes the viewport-height dependency that made the old version fragile there, but it wants a look on a real iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)