### PR TITLE
Let the mobile services scroll normally

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -376,18 +376,6 @@ html[data-idle] *::after {
   animation-play-state: paused !important;
 }
 
-/*
- * Below lg the services are stacked one per screen and snap as you scroll.
- * Proximity rather than mandatory: snap points exist only inside that one
- * section, and mandatory would let a scroll anywhere else on the page get
- * yanked toward them.
- */
-@media (max-width: 1023.98px) {
-  html {
-    scroll-snap-type: y proximity;
-  }
-}
-
 /* Countdown line on the active service tab while the rail is auto-rotating. */
 @keyframes tab-progress {
   from { transform: scaleX(0); }

--- a/components/sales/proof-section.tsx
+++ b/components/sales/proof-section.tsx
@@ -234,19 +234,13 @@ export function ProofSection() {
       </div>
 
       {/*
-        Mobile: one service per screen, snapping as you scroll. Nothing is
-        pinned — a sticky panel fought iOS Safari's collapsing URL bar, which
-        resizes the viewport mid-scroll and made the pin jitter. Ordinary
-        blocks in normal flow have no such problem.
+        Mobile: the services simply stack and scroll. Pinning fought iOS
+        Safari's collapsing URL bar, and snapping made the page decide where
+        the scroll should stop — both got in the reader's way.
       */}
-      <div className="lg:hidden">
+      <div className="lg:hidden pb-16">
         {offerings.map((offering, index) => (
-          <div
-            key={offering.id}
-            // scroll-mt clears the fixed 4rem navbar, which would otherwise
-            // cover the top of each service as it snaps into place.
-            className="snap-start scroll-mt-16 flex min-h-[100svh] flex-col justify-center py-12"
-          >
+          <div key={offering.id} className="py-10 border-t border-border/60 first:border-t-0">
             <div className="container mx-auto px-4">
               <p className="mb-4 text-xs text-muted-foreground tabular-nums">
                 {index + 1} / {offerings.length}


### PR DESCRIPTION
Restores a commit that was lost between the merge of #14 and my deleting that branch.

## What happened

#14 was merged at 18:49. My follow-up commit — removing the scroll snapping, which you'd asked for — landed on the branch at 19:02, *after* the merge. I then deleted the branch, local and remote, which discarded that commit from every branch. It survived only as a dangling object in my local repo and is cherry-picked here.

**Production is currently running the snapping version**, which is the behaviour you asked to remove.

## The change

Both the root `scroll-snap-type` and the per-block snap targets are gone, along with the forced one-service-per-screen height. The six services are plain stacked blocks separated by a hairline rule, sized by their own content — 571–693px rather than a padded 844 each, so the section is 4061px instead of 5064.

Nothing decides the scroll position but the reader.

## Verification

- `tsc --noEmit` — no errors in touched files
- `npm run build` — compiles
- `scroll-snap-type` occurrences in `globals.css`: 0
- `snap-start` occurrences in `proof-section.tsx`: 0
- Previously verified in Chromium at 390×844: html `scroll-snap-type: none`, no block carries a snap alignment, no horizontal overflow, hero static, desktop rail still six tabs and still auto-rotating

🤖 Generated with [Claude Code](https://claude.com/claude-code)