### PR TITLE
Section tabs on /blog, readable post images, shorter hero

### DIFF
--- a/components/blog-listing.tsx
+++ b/components/blog-listing.tsx
@@ -9,6 +9,7 @@ import { Calendar, Clock, ArrowRight, Search, X, Eye, Star } from "lucide-react"
 import Link from "next/link"
 import { Input } from "@/components/ui/input"
 import type { WPBlogPost as BlogPost } from "@/lib/wordpress"
+import { BLOG_CATEGORY_TABS, postsForTab } from "@/lib/blog-categories"
 import { useLanguage } from "@/components/language-provider"
 
 export function BlogListing() {
@@ -22,7 +23,7 @@ export function BlogListing() {
   const selectedCategory = searchParams.get("category")
   const selectedTag = searchParams.get("tag")
   const searchParam = searchParams.get("search")
-  const { language } = useLanguage()
+  const { language, t } = useLanguage()
 
   useEffect(() => {
     async function fetchPosts() {
@@ -154,7 +155,16 @@ export function BlogListing() {
   // Filter posts based on category, tag, or search
   let filteredPosts: BlogPost[] = allPosts
 
-  if (selectedCategory && selectedCategory !== "All") {
+  // A section tab matches the same way the homepage rows do — by category name,
+  // its aliases, or a marker tag — so a post cannot appear in a homepage row
+  // and then be missing from the same section here.
+  const activeTab = BLOG_CATEGORY_TABS.find(
+    (tab) => tab.wpCategory.toLowerCase() === (selectedCategory ?? "").trim().toLowerCase(),
+  )
+
+  if (activeTab) {
+    filteredPosts = postsForTab(filteredPosts, activeTab)
+  } else if (selectedCategory && selectedCategory !== "All") {
     filteredPosts = filteredPosts.filter(post => post.category === selectedCategory)
   }
 
@@ -219,6 +229,34 @@ export function BlogListing() {
       <div className="container px-4 md:px-6 w-full max-w-full">
         <div className="grid gap-10 md:grid-cols-4">
           <div className="md:col-span-3">
+            {/* Section tabs, so a reader can see which part of the blog they are in */}
+            <div className="mb-8 flex flex-wrap items-center gap-1 border-b border-border">
+              {BLOG_CATEGORY_TABS.map((tab) => {
+                const isActive = activeTab?.id === tab.id
+                return (
+                  <Link
+                    key={tab.id}
+                    href={`/blog?category=${encodeURIComponent(tab.wpCategory)}`}
+                    className={`-mb-px border-b-2 px-4 py-3 text-sm font-semibold transition-colors ${
+                      isActive
+                        ? "border-primary text-primary"
+                        : "border-transparent text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    <span suppressHydrationWarning>{t(tab.labelKey)}</span>
+                  </Link>
+                )
+              })}
+              <Link
+                href="/blog"
+                className={`ml-auto px-4 py-3 text-sm transition-colors ${
+                  activeTab ? "text-muted-foreground hover:text-foreground" : "font-semibold text-foreground"
+                }`}
+              >
+                {t("view_all_posts")}
+              </Link>
+            </div>
+
             {displayPosts.length === 0 ? (
               <div className="text-center py-12">
                 <p className="text-muted-foreground mb-4">No posts found matching your criteria.</p>

--- a/components/blog-post-content.tsx
+++ b/components/blog-post-content.tsx
@@ -320,7 +320,7 @@ export function BlogPostContent({ slug }: BlogPostContentProps) {
             {/* Main Content */}
             <div className="overflow-x-hidden">
               <div
-                className="wp-content prose prose-lg max-w-none prose-headings:font-bold prose-headings:text-gray-900 prose-p:text-gray-700 prose-a:text-primary prose-a:no-underline hover:prose-a:underline prose-strong:text-gray-900 prose-code:text-primary prose-code:bg-gray-100 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-gray-900 prose-pre:text-gray-100 prose-img:rounded-lg prose-img:shadow-md prose-img:mx-auto prose-img:w-auto prose-img:max-h-[26rem]"
+                className="wp-content prose prose-lg max-w-none prose-headings:font-bold prose-headings:text-gray-900 prose-p:text-gray-700 prose-a:text-primary prose-a:no-underline hover:prose-a:underline prose-strong:text-gray-900 prose-code:text-primary prose-code:bg-gray-100 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-gray-900 prose-pre:text-gray-100 prose-img:rounded-lg prose-img:shadow-md prose-img:mx-auto prose-img:w-full prose-img:max-w-[36rem] prose-img:max-h-[28rem] prose-img:object-contain"
                 dangerouslySetInnerHTML={{ __html: post.content || "" }} 
               />
             </div>

--- a/components/shader-background.tsx
+++ b/components/shader-background.tsx
@@ -30,7 +30,10 @@ export default function ShaderBackground({ children }: ShaderBackgroundProps) {
   return (
     <div
       id="hero"
-      className="min-h-screen relative overflow-hidden -mt-16 pt-16 transition-colors duration-300"
+      // Deliberately short of a full viewport so the first stories are visible
+      // underneath: a section starting on screen tells a reader there is more
+      // below far better than any prompt to scroll would.
+      className="min-h-[82svh] md:min-h-[78vh] relative overflow-hidden -mt-16 pt-16 transition-colors duration-300"
       style={{
         background: isDark
           ? 'linear-gradient(135deg, #0a0a1a 0%, #1a1030 40%, #0d0820 100%)'


### PR DESCRIPTION
Recovers two commits that missed the #16 merge. The language/category fix from that PR **is** on main; these three changes are not.

## What's here

**Post images render at a usable size.** WordPress serves them with `sizes="auto, …"`. Paired with the `width:auto` I set when capping image height, the browser had no definite layout width to resolve the srcset against and picked a small candidate — a 1024×658 photo came out **314px wide**. Images now take a definite width (full column, capped at 36rem) with height capped at 28rem and `object-contain`, so landscape photos fill the measure and portraits are bounded without distortion. That photo now renders **576×370**.

**Section tabs on `/blog`** — Our Stories · Our Products · Industry News, Our Stories first, plus a "View all posts" link to clear. They match via `postsForTab`, the same rule the homepage rows use, rather than an exact category string: Our Products is the case that would otherwise break, since those posts are marked by tag.

**Hero no longer fills the screen** — `min-h-screen` meant it ended exactly where the viewport did, so nothing signalled that more followed. Now 78vh on desktop, 82svh on phones. No scroll arrow: a section visibly starting below the fold says "there is more" more plainly than a prompt.

## Verification (Chromium)

- Harvard photo: 576×370 rendered, was ~314 wide
- Tabs yield 5 / 3 / 7 posts against 19 total, correct tab highlighted each time
- "Our Stories" heading fully on the first screen at 1440×900 (top 798 of 900), 1440×720 (658 of 720) and 390×844 (772 of 844)
- Hero copy and button still fit at every size, including the short 720px laptop
- `tsc --noEmit` clean on touched files; `npm run build` compiles

## Note

Verified `git diff` between the recovered branch and the lost one is empty — nothing else from #16 is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)