### PR TITLE
Rate-limit failed admin login attempts

### DIFF
--- a/app/api/admin/content/route.ts
+++ b/app/api/admin/content/route.ts
@@ -10,14 +10,14 @@ import {
 
 export const dynamic = "force-dynamic"
 
-function guard(request: NextRequest): NextResponse | null {
+async function guard(request: NextRequest): Promise<NextResponse | null> {
   if (!isAdminConfigured()) {
     return NextResponse.json(
       { error: "ADMIN_PASSWORD is not configured on the server." },
       { status: 503 },
     )
   }
-  if (!isAdmin(request)) {
+  if (!(await isAdmin(request))) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
   if (!isBlobConfigured()) {
@@ -31,14 +31,14 @@ function guard(request: NextRequest): NextResponse | null {
 
 // GET — authoritative current content (admin editor convenience).
 export async function GET(request: NextRequest) {
-  const blocked = guard(request)
+  const blocked = await guard(request)
   if (blocked) return blocked
   return NextResponse.json(await readContent())
 }
 
 // PUT — overwrite content. Body merges over current so partial section writes are allowed.
 export async function PUT(request: NextRequest) {
-  const blocked = guard(request)
+  const blocked = await guard(request)
   if (blocked) return blocked
 
   let body: Partial<SiteContent>
@@ -75,7 +75,7 @@ export async function PUT(request: NextRequest) {
 
 // POST — multipart image upload (returns { url }). Empty form acts as the login probe.
 export async function POST(request: NextRequest) {
-  const blocked = guard(request)
+  const blocked = await guard(request)
   if (blocked) return blocked
 
   const form = await request.formData()

--- a/app/api/admin/tecxbook/[slug]/route.ts
+++ b/app/api/admin/tecxbook/[slug]/route.ts
@@ -19,7 +19,7 @@ export async function PATCH(request: NextRequest, { params }: Params) {
       { status: 503 },
     )
   }
-  if (!isAdmin(request)) {
+  if (!(await isAdmin(request))) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
   if (!isBlobConfigured()) {
@@ -86,7 +86,7 @@ export async function DELETE(request: NextRequest, { params }: Params) {
       { status: 503 },
     )
   }
-  if (!isAdmin(request)) {
+  if (!(await isAdmin(request))) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
   if (!isBlobConfigured()) {

--- a/app/api/admin/tecxbook/route.ts
+++ b/app/api/admin/tecxbook/route.ts
@@ -18,7 +18,7 @@ export async function POST(request: NextRequest) {
       { status: 503 },
     )
   }
-  if (!isAdmin(request)) {
+  if (!(await isAdmin(request))) {
     return NextResponse.json(
       { error: "Unauthorized" },
       { status: 401 },

--- a/app/api/vcards/route.ts
+++ b/app/api/vcards/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest) {
   if (!isAdminConfigured()) {
     return NextResponse.json({ error: "ADMIN_PASSWORD is not configured on the server." }, { status: 503 })
   }
-  if (!isAdmin(request)) {
+  if (!(await isAdmin(request))) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
   return NextResponse.json(vcards as VCardData[])

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,4 +1,5 @@
 import { createHash, timingSafeEqual } from "crypto"
+import { Redis } from "@upstash/redis"
 import type { NextRequest } from "next/server"
 
 function getAllowlist(): string[] {
@@ -22,10 +23,68 @@ function matchesPassword(candidate: string, provided: string): boolean {
   return timingSafeEqual(candidateHash, providedHash)
 }
 
-export function isAdmin(request: NextRequest): boolean {
+function getRedis(): Redis | null {
+  if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) return null
+  return Redis.fromEnv()
+}
+
+function clientIp(request: NextRequest): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown"
+  )
+}
+
+const MAX_FAILED_ATTEMPTS = 10
+const LOCKOUT_WINDOW_SECONDS = 600 // 10 minutes
+
+function failKey(ip: string): string {
+  return `admin:auth-fail:${createHash("sha256").update(ip).digest("hex").slice(0, 32)}`
+}
+
+// Counts failed password attempts per IP, not every admin request — the
+// dashboard re-sends the password header on every action after login, so
+// rate-limiting all traffic would eventually lock out a legitimate admin
+// mid-edit. Only wrong guesses count, so normal usage never trips it.
+// Fails open (no lockout) if Redis isn't configured or errors, matching the
+// rest of the codebase: an outage degrades protection, it doesn't lock out
+// the only person who can fix it.
+async function isLockedOut(request: NextRequest): Promise<boolean> {
+  const redis = getRedis()
+  if (!redis) return false
+  try {
+    const count = (await redis.get<number>(failKey(clientIp(request)))) ?? 0
+    return count >= MAX_FAILED_ATTEMPTS
+  } catch {
+    return false
+  }
+}
+
+async function recordFailedAttempt(request: NextRequest): Promise<void> {
+  const redis = getRedis()
+  if (!redis) return
+  try {
+    const key = failKey(clientIp(request))
+    const count = await redis.incr(key)
+    if (count === 1) await redis.expire(key, LOCKOUT_WINDOW_SECONDS)
+  } catch {
+    // best-effort — a failed increment just means this attempt doesn't count
+  }
+}
+
+export async function isAdmin(request: NextRequest): Promise<boolean> {
   const allow = getAllowlist()
   if (allow.length === 0) return false
   const provided = request.headers.get("x-admin-password")
   if (!provided) return false
-  return allow.some((candidate) => matchesPassword(candidate, provided))
+
+  // Denied the same way as a wrong password (plain 401) rather than a
+  // distinct "too many attempts" response, so a brute-forcer can't tell
+  // lockout from a bad guess and time their next try accordingly.
+  if (await isLockedOut(request)) return false
+
+  const matched = allow.some((candidate) => matchesPassword(candidate, provided))
+  if (!matched) await recordFailedAttempt(request)
+  return matched
 }


### PR DESCRIPTION
## Summary
Follow-up from the security review that led to PR #18. The admin password check itself is now constant-time (#18), but there was still no brute-force protection — once `ADMIN_PASSWORD` is rotated to a strong value, an attacker with unlimited login attempts can still eventually guess it.

- `isAdmin()` now locks out an IP after **10 failed attempts within a 10-minute window**, tracked in the same Upstash Redis instance the chatbot already uses for rate limiting (mirrors `enforceChatRateLimit` in `lib/chatbot.ts`).
- Only **wrong** guesses count — the admin dashboard re-sends the password header on every action after login (there's no session token), but it only actually *probes* the password once via an empty-form `POST` and caches the result client-side. So this only throttles bad guesses, never normal editing traffic.
- **Fails open** if Redis isn't configured or errors, same philosophy as the rest of the codebase (an outage degrades protection rather than locking out the one person who can fix it).
- A lockout returns the same `401` as a wrong password — a brute-forcer can't tell "locked out" from "bad guess" and adjust their timing accordingly.
- `isAdmin()` is now `async` (it may check/increment Redis); updated all four call sites (`/api/admin/content`, `/api/admin/tecxbook`, `/api/admin/tecxbook/[slug]`, `/api/vcards`).

## Test plan
- [x] `pnpm run build` — clean
- [x] `npx tsc --noEmit` — clean on every touched file (4 pre-existing unrelated errors elsewhere in the repo, untouched by this change)
- [x] Live smoke test against a running server with `ADMIN_PASSWORD` set and no Redis configured: correct password passes the auth gate, wrong password → 401, missing password → 401 — confirms the fail-open path doesn't regress normal auth
- [ ] Could not test the actual Redis-backed lockout end-to-end (no Upstash credentials in this environment) — logic mirrors the already-proven `enforceChatRateLimit` pattern exactly. Worth a manual check against the real Upstash instance after merge: 11 rapid wrong-password requests from one IP should return 401 with the 11th indistinguishable from the others, then succeed again after ~10 minutes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwF4AQSSx8TQ4M3PCs4Myq)_