### PR TITLE
Rate-limit blog likes/views and fix their dead Redis-fallback check

### DIFF
--- a/app/api/blog/likes/route.ts
+++ b/app/api/blog/likes/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { Redis } from '@upstash/redis'
+import { checkRateLimit, clientIp } from '@/lib/rate-limit'
 
 // Initialize Redis using environment variables
 const redis = Redis.fromEnv()
@@ -13,6 +14,22 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: 'Invalid slug' },
         { status: 400 }
+      )
+    }
+
+    // A click toggles this once; an unbounded increment otherwise lets
+    // anyone script arbitrary like-count inflation. 30/10min per IP is well
+    // above normal like/unlike toggling.
+    const rate = await checkRateLimit({
+      scope: 'blog-likes',
+      identity: clientIp(request),
+      limit: 30,
+      windowSeconds: 600,
+    })
+    if (!rate.ok) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429, headers: { 'Retry-After': String(rate.retryAfterSeconds) } },
       )
     }
 
@@ -53,8 +70,13 @@ export async function POST(request: NextRequest) {
     }
   } catch (error) {
     console.error('Error toggling like:', error)
-    // If Redis is not configured, return gracefully
-    if (error instanceof Error && error.message.includes('UPSTASH')) {
+    // If Redis isn't configured, return gracefully. Checking the env vars
+    // directly (rather than pattern-matching the thrown error's message) is
+    // what the intent here actually needs: the SDK's real failure text for
+    // a missing URL/token doesn't contain "UPSTASH" at all, so that check
+    // never matched and every Redis hiccup — configured or not — was
+    // falling through to a hard 500.
+    if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
       return NextResponse.json({
         success: true,
         likes: 0,

--- a/app/api/blog/views/route.ts
+++ b/app/api/blog/views/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { Redis } from '@upstash/redis'
+import { checkRateLimit, clientIp } from '@/lib/rate-limit'
 
 // Initialize Redis using environment variables
 // Redis.fromEnv() automatically reads UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN
@@ -7,13 +8,30 @@ const redis = Redis.fromEnv()
 
 // Track a view for a blog post
 export async function POST(request: NextRequest) {
+  let slug: unknown
   try {
-    const { slug } = await request.json()
+    ;({ slug } = await request.json())
 
     if (!slug || typeof slug !== 'string') {
       return NextResponse.json(
         { error: 'Invalid slug' },
         { status: 400 }
+      )
+    }
+
+    // Fires once per page load, but an unbounded increment lets anyone
+    // script arbitrary view-count inflation. 60/10min per IP comfortably
+    // covers a reader browsing many posts while blocking spam.
+    const rate = await checkRateLimit({
+      scope: 'blog-views',
+      identity: clientIp(request),
+      limit: 60,
+      windowSeconds: 600,
+    })
+    if (!rate.ok) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429, headers: { 'Retry-After': String(rate.retryAfterSeconds) } },
       )
     }
 
@@ -29,8 +47,13 @@ export async function POST(request: NextRequest) {
     })
   } catch (error) {
     console.error('Error tracking view:', error)
-    // If Redis is not configured, return 0 views gracefully
-    if (error instanceof Error && error.message.includes('UPSTASH')) {
+    // If Redis isn't configured, return 0 views gracefully. Checking the env
+    // vars directly (rather than pattern-matching the thrown error's
+    // message) is what the intent here actually needs: the SDK's real
+    // failure text for a missing URL/token doesn't contain "UPSTASH" at
+    // all, so that check never matched and every Redis hiccup — configured
+    // or not — was falling through to a hard 500.
+    if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
       return NextResponse.json({
         success: true,
         views: 0,

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,44 @@
+import { createHash } from "crypto"
+import { Redis } from "@upstash/redis"
+
+let cachedRedis: Redis | null | undefined
+
+// Shared by any route that needs a cheap per-IP throttle. Fails open (no
+// Redis configured, or a Redis error) so an outage degrades protection
+// rather than taking the endpoint down — same policy as the rest of the
+// codebase's rate limiters (lib/chatbot.ts, lib/quote.ts).
+function getRedis(): Redis | null {
+  if (cachedRedis !== undefined) return cachedRedis
+  cachedRedis =
+    process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN ? Redis.fromEnv() : null
+  return cachedRedis
+}
+
+export async function checkRateLimit(input: {
+  scope: string
+  identity: string
+  limit: number
+  windowSeconds: number
+}): Promise<{ ok: true } | { ok: false; retryAfterSeconds: number }> {
+  const redis = getRedis()
+  if (!redis) return { ok: true }
+  try {
+    const hash = createHash("sha256").update(input.identity).digest("hex").slice(0, 32)
+    const key = `ratelimit:${input.scope}:${hash}`
+    const count = await redis.incr(key)
+    if (count === 1) await redis.expire(key, input.windowSeconds)
+    if (count > input.limit) return { ok: false, retryAfterSeconds: input.windowSeconds }
+  } catch (error) {
+    console.warn(`[rate-limit:${input.scope}] unavailable, allowing through:`, error)
+  }
+  return { ok: true }
+}
+
+export function clientIp(request: Request): string {
+  const headers = request.headers
+  return (
+    headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    headers.get("x-real-ip") ||
+    "unknown"
+  )
+}


### PR DESCRIPTION
## Summary
- `/api/blog/likes` and `/api/blog/views` `POST` had no rate limiting: any anonymous caller could script-spam either to arbitrarily inflate public like/view counts via an unbounded `redis.incr()`. Added a per-IP limit (30/10min for likes, 60/10min for views — generous relative to actual browsing/toggling patterns) via a small shared helper, `lib/rate-limit.ts`, following the same fail-open-if-Redis-unavailable pattern already used by the chat and quote rate limiters.
- **Found and fixed while testing**: both routes' "Redis not configured, degrade gracefully" fallback checked `error.message.includes('UPSTASH')`, but the SDK's actual failure text for a missing URL/token (`Failed to parse URL from /pipeline`) never contains that string. The fallback was dead code — any Redis hiccup, configured or not, fell through to a hard 500 instead of the intended graceful degradation. Now checks the env vars directly, which is both correct and matches the original intent (soft-fail only when truly unconfigured, surface real outages as 500s otherwise).
- Also fixed a reference-before-assignment bug in `blog/views`: `slug` was destructured inside the `try` block but read in the `catch` block, where it's out of scope — a real crash waiting to happen on any error path, caught by a clean `tsc --noEmit` run while touching this file for the above.

## Test plan
- [x] `pnpm run build` — clean
- [x] `npx tsc --noEmit` — no new errors (3 pre-existing unrelated ones remain, down from 4 before the `slug` fix)
- [x] Live run against both endpoints (no Redis configured locally): confirmed the graceful-fallback path now actually returns `{success:true, ...: 0, warning: "Redis not configured"}` instead of a 500, and `400` validation on a missing slug still works
- [ ] Could not exercise the real `429` path — no Upstash credentials in this environment — but the limiter logic in `lib/rate-limit.ts` is identical to the already-proven `enforceChatRateLimit`/`enforceQuoteRateLimit` implementations elsewhere in the codebase

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwF4AQSSx8TQ4M3PCs4Myq)_