### PR TITLE
Make the homepage hero call-to-action editable from the admin panel

### DIFF
--- a/app/admin/about/page.tsx
+++ b/app/admin/about/page.tsx
@@ -25,7 +25,11 @@ type Status = { kind: "idle" } | { kind: "ok"; msg: string } | { kind: "err"; ms
 
 function AboutEditor() {
   const { authedFetch } = useAdminContext()
-  const [hero, setHero] = useState<SiteContent["hero"]>({ title: EMPTY_LOCALIZED, subtitle: EMPTY_LOCALIZED })
+  const [hero, setHero] = useState<SiteContent["hero"]>({
+    title: EMPTY_LOCALIZED,
+    subtitle: EMPTY_LOCALIZED,
+    cta: { label: EMPTY_LOCALIZED, url: "" },
+  })
   const [subtitle, setSubtitle] = useState<Localized>(EMPTY_LOCALIZED)
   const [sections, setSections] = useState<AboutSection[]>([])
   const [locale, setLocale] = useState<Locale>("en")
@@ -37,7 +41,14 @@ function AboutEditor() {
     fetch("/api/content", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : null))
       .then((c: SiteContent | null) => {
-        if (c?.hero) setHero(c.hero)
+        if (c?.hero) {
+          // Backfill cta for content blobs saved before it became editable,
+          // so the inputs below always have a value to bind to.
+          setHero({
+            ...c.hero,
+            cta: c.hero.cta ?? { label: EMPTY_LOCALIZED, url: "" },
+          })
+        }
         if (c?.about) {
           setSubtitle(c.about.subtitle)
           setSections(c.about.sections)
@@ -48,6 +59,12 @@ function AboutEditor() {
 
   const setHeroField = (field: "title" | "subtitle", value: string) =>
     setHero((prev) => ({ ...prev, [field]: { ...prev[field], [locale]: value } }))
+
+  const setCtaLabel = (value: string) =>
+    setHero((prev) => ({ ...prev, cta: { ...prev.cta, label: { ...prev.cta.label, [locale]: value } } }))
+
+  const setCtaUrl = (value: string) =>
+    setHero((prev) => ({ ...prev, cta: { ...prev.cta, url: value } }))
 
   const updateSection = useCallback((idx: number, patch: Partial<AboutSection>) => {
     setSections((prev) => prev.map((s, i) => (i === idx ? { ...s, ...patch } : s)))
@@ -161,6 +178,34 @@ function AboutEditor() {
             rows={2}
             className="w-full rounded-md border px-3 py-2 text-sm bg-background"
           />
+        </div>
+        <div className="border-t pt-3 space-y-3">
+          <p className="text-xs font-semibold text-muted-foreground">Call-to-action button</p>
+          <div>
+            <label className="block text-xs font-medium text-muted-foreground mb-1">Button label ({L})</label>
+            <input
+              value={hero.cta.label[locale]}
+              onChange={(e) => setCtaLabel(e.target.value)}
+              placeholder="Book a consultation call"
+              className="w-full rounded-md border px-3 py-2 text-sm bg-background"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-muted-foreground mb-1">
+              Button link <span className="font-normal normal-case">(same for all languages)</span>
+            </label>
+            <input
+              type="url"
+              inputMode="url"
+              value={hero.cta.url}
+              onChange={(e) => setCtaUrl(e.target.value)}
+              placeholder="https://cal.com/nikolasdoan/30min"
+              className="w-full rounded-md border px-3 py-2 text-sm bg-background"
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Where the hero button sends visitors — e.g. your booking link, contact page, or a mailto: address.
+            </p>
+          </div>
         </div>
       </section>
 

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -24,6 +24,12 @@ export function HeroSection() {
   const title = hero ? hero.title[language] || hero.title.en : t("hero_title")
   const subtitle = hero ? hero.subtitle[language] || hero.subtitle.en : t("hero_subtitle")
 
+  // CTA label and destination are admin-editable. Fall back to the i18n label
+  // and the original booking link until live content loads (or if an older
+  // content blob predates the editable CTA).
+  const ctaLabel = hero?.cta?.label?.[language] || hero?.cta?.label?.en || t("book_call")
+  const ctaUrl = hero?.cta?.url || "https://cal.com/nikolasdoan/30min"
+
   return (
     <ShaderBackground>
       <div className="absolute inset-0 flex flex-col items-start justify-center px-8 md:px-8 pt-20 pb-24 z-10">
@@ -39,8 +45,8 @@ export function HeroSection() {
             className="bg-primary hover:bg-primary/90 text-white text-base px-8 py-6 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 self-start"
             asChild
           >
-          <a href="https://cal.com/nikolasdoan/30min" target="_blank" rel="noopener noreferrer">
-              {t("book_call")}
+          <a href={ctaUrl} target="_blank" rel="noopener noreferrer">
+              {ctaLabel}
             </a>
           </Button>
         </div>

--- a/lib/site-content.ts
+++ b/lib/site-content.ts
@@ -151,7 +151,7 @@ export const defaultSectionVisibility: SectionVisibility = {
 export type SiteContent = {
   settings: { sections: SectionVisibility; homepageOrder?: HomepageSectionKey[] }
   team: TeamMember[]
-  hero: { title: Localized; subtitle: Localized }
+  hero: { title: Localized; subtitle: Localized; cta: { label: Localized; url: string } }
   services: { title: Localized; items: Service[] }
   chatbot: ChatbotConfig
   about: { subtitle: Localized; sections: AboutSection[] }
@@ -243,6 +243,10 @@ export const defaultContent: SiteContent = {
       "Công nghệ có thể mở ra tiềm năng thật sự cho doanh nghiệp bạn. Hãy cùng khám phá.",
       "科技能為您的企業打開真正的潛力。一起來探索。",
     ),
+    cta: {
+      label: M("Book a consultation call", "Đặt lịch tư vấn", "預約諮詢通話"),
+      url: "https://cal.com/nikolasdoan/30min",
+    },
   },
   services: {
     title: M("Our Services", "Dịch vụ của chúng tôi", "我們的服務"),
@@ -556,6 +560,17 @@ function mergeContent(stored?: Partial<SiteContent>): SiteContent {
         subtitle: {
           ...defaultContent.hero.subtitle,
           ...stored.hero?.subtitle,
+        },
+        cta: {
+          label: {
+            ...defaultContent.hero.cta.label,
+            ...stored.hero?.cta?.label,
+          },
+          // Empty string is a valid "cleared" URL only if intentional; treat a
+          // missing/blank stored URL as "use the default" so an older saved
+          // content blob (written before the CTA was editable) still renders
+          // the working calendar link instead of a dead button.
+          url: stored.hero?.cta?.url?.trim() || defaultContent.hero.cta.url,
         },
       }
 


### PR DESCRIPTION
## Summary
You asked to polish the admin panel so it can edit the things you change frequently on the homepage. I audited what the admin already edits (hero title/subtitle, services, team, about, company/footer, SEO, visibility, chatbot) against what the homepage actually renders, and found the highest-value gap: **the hero button** — the primary conversion point — had both its label and its destination URL **hardcoded** in `components/hero-section.tsx`. The label came from an i18n constant and the URL was a literal `https://cal.com/nikolasdoan/30min` in the JSX. Changing where that button sends people (or its wording) meant a developer code edit and a redeploy every single time.

This makes it editable from the existing **Hero & About** admin screen, right below the title/subtitle you can already edit:

- Added `hero.cta { label: Localized; url: string }` to the `SiteContent` model, defaulting to **exactly today's live values** — so nothing changes visually until someone edits it.
- `mergeContent` merges the new field for both fresh and legacy content blobs. A missing or blank stored URL falls back to the default, so an older saved blob (written before the CTA was editable) can't produce a dead button.
- `hero-section.tsx` reads the label (per active language) and URL from live content, falling back to the i18n label and original link until content loads.
- The admin editor gains a **Call-to-action** block: a per-language button label and a single shared button link, with helper text pointing at common uses (booking link, contact page, `mailto:`).

## Test plan
- [x] `pnpm run build` — clean
- [x] `npx tsc --noEmit` — no new errors (same 4 pre-existing unrelated ones as `main`)
- [x] Live run: `/api/content` serves the localized default CTA (`{en: "Book a consultation call", vi: "Đặt lịch tư vấn", zh: "預約諮詢通話"}` + the cal.com URL); `/admin/about` and `/` both return 200
- [x] Blank/missing-URL fallback verified across 5 input shapes (custom URL kept; whitespace-only, empty-object, missing-cta, and empty-stored all resolve to the working default)
- [ ] Could not test end-to-end **persistence** (saving a custom CTA and seeing it survive) — that needs `BLOB_READ_WRITE_TOKEN`, which isn't set in this environment. The read/merge/render path is fully verified; the write path is unchanged plumbing that already works for the hero title/subtitle this sits beside. Worth one manual save-and-refresh in the real admin after merge.

## Note
The default URL (`https://cal.com/nikolasdoan/30min`) is preserved verbatim from the current code so behavior is identical on deploy. Once merged you can change it — and the button label per language — from **Admin → Hero & About → Call-to-action**, no redeploy needed (changes go live within ~60s, same as the other content fields).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwF4AQSSx8TQ4M3PCs4Myq)_