### PR TITLE
Make hero logos, bottom CTA, and proof stat figures admin-editable

### DIFF
--- a/app/admin/homepage/page.tsx
+++ b/app/admin/homepage/page.tsx
@@ -1,0 +1,263 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { AdminShell, useAdminContext } from "@/components/admin/admin-shell"
+import { salesDeck, pickLocale } from "@/lib/sales-deck"
+import type { HomepageBlocks, Locale, Localized, SiteContent } from "@/lib/site-content"
+
+const LOCALES: { code: Locale; label: string }[] = [
+  { code: "en", label: "EN" },
+  { code: "vi", label: "VI" },
+  { code: "zh", label: "ZH" },
+]
+
+const EMPTY_LOCALIZED: Localized = { en: "", vi: "", zh: "" }
+
+// Fallback shape until content loads / for any missing field.
+const EMPTY_HOMEPAGE: HomepageBlocks = {
+  heroLogos: { enabled: false, caption: { ...EMPTY_LOCALIZED }, items: [] },
+  cta: {
+    title: { ...EMPTY_LOCALIZED },
+    body: { ...EMPTY_LOCALIZED },
+    buttonLabel: { ...EMPTY_LOCALIZED },
+    url: "",
+  },
+  proofMetrics: [],
+}
+
+type Status = { kind: "idle" } | { kind: "ok"; msg: string } | { kind: "err"; msg: string }
+
+function labelCls() {
+  return "block text-xs font-medium text-muted-foreground mb-1"
+}
+function inputCls() {
+  return "w-full rounded-md border px-3 py-2 text-sm bg-background"
+}
+
+function HomepageEditor() {
+  const { authedFetch } = useAdminContext()
+  const [hp, setHp] = useState<HomepageBlocks>(EMPTY_HOMEPAGE)
+  const [locale, setLocale] = useState<Locale>("en")
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [status, setStatus] = useState<Status>({ kind: "idle" })
+
+  useEffect(() => {
+    fetch("/api/content", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((c: SiteContent | null) => {
+        if (c?.homepage) setHp({ ...EMPTY_HOMEPAGE, ...c.homepage })
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  // ---- hero logos ----
+  const setLogosEnabled = (v: boolean) => setHp((p) => ({ ...p, heroLogos: { ...p.heroLogos, enabled: v } }))
+  const setLogosCaption = (v: string) =>
+    setHp((p) => ({ ...p, heroLogos: { ...p.heroLogos, caption: { ...p.heroLogos.caption, [locale]: v } } }))
+  const setLogoField = (idx: number, field: "name" | "src", v: string) =>
+    setHp((p) => ({
+      ...p,
+      heroLogos: {
+        ...p.heroLogos,
+        items: p.heroLogos.items.map((it, i) => (i === idx ? { ...it, [field]: v } : it)),
+      },
+    }))
+  const addLogo = () =>
+    setHp((p) => ({ ...p, heroLogos: { ...p.heroLogos, items: [...p.heroLogos.items, { name: "", src: "" }] } }))
+  const removeLogo = (idx: number) =>
+    setHp((p) => ({ ...p, heroLogos: { ...p.heroLogos, items: p.heroLogos.items.filter((_, i) => i !== idx) } }))
+  const moveLogo = (idx: number, dir: -1 | 1) =>
+    setHp((p) => {
+      const items = [...p.heroLogos.items]
+      const t = idx + dir
+      if (t < 0 || t >= items.length) return p
+      ;[items[idx], items[t]] = [items[t], items[idx]]
+      return { ...p, heroLogos: { ...p.heroLogos, items } }
+    })
+
+  // ---- cta ----
+  const setCta = (field: "title" | "body" | "buttonLabel", v: string) =>
+    setHp((p) => ({ ...p, cta: { ...p.cta, [field]: { ...p.cta[field], [locale]: v } } }))
+  const setCtaUrl = (v: string) => setHp((p) => ({ ...p, cta: { ...p.cta, url: v } }))
+
+  // ---- proof metrics ----
+  // Offerings are code-defined (lib/sales-deck.ts); the admin only edits their
+  // stat figures. Resolve each offering's current metrics from the override in
+  // state, falling back to the code default so the fields are never blank.
+  const metricsFor = (offeringId: string) => {
+    const override = hp.proofMetrics.find((m) => m.offeringId === offeringId)
+    if (override) return override.metrics
+    const fromDeck = salesDeck.proof.offerings.find((o) => o.id === offeringId)
+    return fromDeck ? fromDeck.metrics : []
+  }
+  const setMetric = (offeringId: string, metricIdx: number, field: "label" | "value", v: string) =>
+    setHp((p) => {
+      const current = metricsFor(offeringId)
+      const nextMetrics = current.map((m, i) =>
+        i === metricIdx ? { ...m, [field]: { ...m[field], [locale]: v } } : m,
+      )
+      const exists = p.proofMetrics.some((m) => m.offeringId === offeringId)
+      const proofMetrics = exists
+        ? p.proofMetrics.map((m) => (m.offeringId === offeringId ? { ...m, metrics: nextMetrics } : m))
+        : [...p.proofMetrics, { offeringId, metrics: nextMetrics }]
+      return { ...p, proofMetrics }
+    })
+
+  const save = async () => {
+    setSaving(true)
+    setStatus({ kind: "idle" })
+    try {
+      const res = await authedFetch("/api/admin/content", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ homepage: hp }),
+      })
+      const j = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setStatus({ kind: "err", msg: j.error || "Save failed" })
+        return
+      }
+      setStatus({ kind: "ok", msg: "Saved. Changes are live within ~60s." })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>
+
+  const L = locale.toUpperCase()
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <div className="flex items-center justify-between sticky top-0 bg-muted/20 py-2 z-10">
+        <div className="inline-flex rounded-md border bg-card p-0.5 text-sm">
+          {LOCALES.map((l) => (
+            <button
+              key={l.code}
+              onClick={() => setLocale(l.code)}
+              className={`px-3 py-1 rounded ${locale === l.code ? "bg-primary text-primary-foreground" : "text-muted-foreground"}`}
+            >
+              {l.label}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-3">
+          {status.kind === "ok" && <span className="text-sm text-green-600">{status.msg}</span>}
+          {status.kind === "err" && <span className="text-sm text-red-600">{status.msg}</span>}
+          <button
+            onClick={save}
+            disabled={saving}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+          >
+            {saving ? "Saving…" : "Save changes"}
+          </button>
+        </div>
+      </div>
+
+      {/* Hero partner logos */}
+      <section className="rounded-lg border bg-card p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold">Hero partner logos</h2>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={hp.heroLogos.enabled}
+              onChange={(e) => setLogosEnabled(e.target.checked)}
+            />
+            Show on homepage
+          </label>
+        </div>
+        <div>
+          <label className={labelCls()}>Caption ({L})</label>
+          <input value={hp.heroLogos.caption[locale]} onChange={(e) => setLogosCaption(e.target.value)} className={inputCls()} />
+        </div>
+        <div className="space-y-2">
+          <label className={labelCls()}>Logos (name + image path)</label>
+          {hp.heroLogos.items.map((logo, idx) => (
+            <div key={idx} className="flex items-center gap-2">
+              <input
+                value={logo.name}
+                onChange={(e) => setLogoField(idx, "name", e.target.value)}
+                placeholder="Name"
+                className="w-40 rounded-md border px-2 py-1.5 text-sm bg-background"
+              />
+              <input
+                value={logo.src}
+                onChange={(e) => setLogoField(idx, "src", e.target.value)}
+                placeholder="/logos/example.png"
+                className="flex-1 rounded-md border px-2 py-1.5 text-sm bg-background"
+              />
+              <button onClick={() => moveLogo(idx, -1)} disabled={idx === 0} className="rounded border px-2 py-1 text-sm disabled:opacity-40">↑</button>
+              <button onClick={() => moveLogo(idx, 1)} disabled={idx === hp.heroLogos.items.length - 1} className="rounded border px-2 py-1 text-sm disabled:opacity-40">↓</button>
+              <button onClick={() => removeLogo(idx)} className="rounded border px-2 py-1 text-sm text-red-600">✕</button>
+            </div>
+          ))}
+          <button onClick={addLogo} className="rounded-md border px-3 py-1.5 text-sm">+ Add logo</button>
+          <p className="text-xs text-muted-foreground">
+            Image path is under <code>/public</code> (e.g. <code>/logos/example.png</code>) or a full https URL.
+          </p>
+        </div>
+      </section>
+
+      {/* Bottom CTA band */}
+      <section className="rounded-lg border bg-card p-4 space-y-3">
+        <h2 className="text-sm font-semibold">Bottom call-to-action</h2>
+        <div>
+          <label className={labelCls()}>Heading ({L})</label>
+          <input value={hp.cta.title[locale]} onChange={(e) => setCta("title", e.target.value)} className={inputCls()} />
+        </div>
+        <div>
+          <label className={labelCls()}>Body ({L})</label>
+          <textarea value={hp.cta.body[locale]} onChange={(e) => setCta("body", e.target.value)} rows={2} className={inputCls()} />
+        </div>
+        <div>
+          <label className={labelCls()}>Button label ({L})</label>
+          <input value={hp.cta.buttonLabel[locale]} onChange={(e) => setCta("buttonLabel", e.target.value)} className={inputCls()} />
+        </div>
+        <div>
+          <label className={labelCls()}>Button link <span className="font-normal normal-case">(same for all languages)</span></label>
+          <input type="url" inputMode="url" value={hp.cta.url} onChange={(e) => setCtaUrl(e.target.value)} placeholder="https://cal.com/nikolasdoan/30min" className={inputCls()} />
+        </div>
+      </section>
+
+      {/* Proof stat figures */}
+      <section className="rounded-lg border bg-card p-4 space-y-4">
+        <div>
+          <h2 className="text-sm font-semibold">Proof section — stat figures</h2>
+          <p className="text-xs text-muted-foreground mt-1">
+            The two figures shown under each service. Service names and descriptions stay in code; only these numbers are editable here.
+          </p>
+        </div>
+        {salesDeck.proof.offerings.map((offering) => {
+          const metrics = metricsFor(offering.id)
+          return (
+            <div key={offering.id} className="rounded-md border bg-background p-3 space-y-3">
+              <p className="text-sm font-medium">{pickLocale(offering.title, locale)}</p>
+              {metrics.map((m, i) => (
+                <div key={i} className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className={labelCls()}>Label ({L})</label>
+                    <input value={m.label[locale]} onChange={(e) => setMetric(offering.id, i, "label", e.target.value)} className={inputCls()} />
+                  </div>
+                  <div>
+                    <label className={labelCls()}>Value ({L})</label>
+                    <input value={m.value[locale]} onChange={(e) => setMetric(offering.id, i, "value", e.target.value)} className={inputCls()} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )
+        })}
+      </section>
+    </div>
+  )
+}
+
+export default function HomepageBlocksPage() {
+  return (
+    <AdminShell title="Homepage Blocks">
+      <HomepageEditor />
+    </AdminShell>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -9,6 +9,7 @@ const CARDS = [
   { href: "/admin/services", label: "Services", desc: "Service card titles and descriptions.", ready: true },
   { href: "/admin/chatbot", label: "Chatbot", desc: "Prompt, memory, escalation copy, and recent support transcripts.", ready: true },
   { href: "/admin/about", label: "Hero & About", desc: "Homepage hero and About page copy.", ready: true },
+  { href: "/admin/homepage", label: "Homepage Blocks", desc: "Partner logos, bottom call-to-action, and proof stat figures.", ready: true },
   { href: "/admin/company", label: "Company & Footer", desc: "Address, phones, emails, markets, legal names, social links.", ready: true },
   { href: "/admin/metadata", label: "Metadata (SEO)", desc: "Page titles, descriptions, OG tags.", ready: true },
   { href: "/admin/tecxbook", label: "Tecxbook", desc: "Upload and manage HTML artifacts.", ready: true },

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -51,7 +51,7 @@ export function HeroSection() {
           </Button>
         </div>
       </div>
-      {/* <LogoCarousel /> */}
+      <LogoCarousel />
     </ShaderBackground>
   )
 }

--- a/components/logo-carousel.tsx
+++ b/components/logo-carousel.tsx
@@ -2,48 +2,48 @@
 
 import Image from "next/image"
 import { InfiniteSlider } from "@/components/ui/infinite-slider"
+import { useLanguage } from "@/components/language-provider"
+import { useSiteContent } from "@/lib/use-site-content"
+
+// Fallback logos + caption, used until live content loads. Mirrors the
+// defaults in lib/site-content.ts so the carousel looks the same either way.
+const FALLBACK_LOGOS = [
+  { name: "Crypted", src: "/logos/crypted.png" },
+  { name: "HealthMaxers", src: "/logos/healthmaxers.png" },
+  { name: "IPRP Shield", src: "/logos/IPRPSHIELD.png" },
+  { name: "CHI CHI Vietnamese", src: "/logos/chichi.png" },
+]
 
 export function LogoCarousel() {
-  // Removed mobile detection to reduce TBT - use CSS media queries instead
-  const logos = [
-    {
-      name: "Crypted",
-      src: "/logos/crypted.png",
-    },
-    {
-      name: "HealthMaxers",
-      src: "/logos/healthmaxers.png",
-    },
-    {
-      name: "IPRP Shield",
-      src: "/logos/IPRPSHIELD.png",
-    },
-    {
-      name: "CHI CHI Vietnamese",
-      src: "/logos/chichi.png",
-    },
-  ]
+  const { language } = useLanguage()
+  const content = useSiteContent()
+  const config = content?.homepage?.heroLogos
+
+  // Hidden unless an admin has turned it on. `config === undefined` means
+  // content hasn't loaded yet — stay hidden rather than flashing the carousel
+  // in and out, since the default state is off anyway.
+  if (!config?.enabled) return null
+
+  const logos = config.items?.length ? config.items : FALLBACK_LOGOS
+  if (logos.length === 0) return null
+
+  const caption = config.caption?.[language] || config.caption?.en || "with partners from"
 
   return (
     <div className="absolute left-4 md:left-8 right-4 bottom-24 md:bottom-20">
       <div className="flex items-center gap-2 md:gap-4">
         <div className="flex-shrink-0">
           <div className="flex flex-col text-left">
-            <span className="text-xs md:text-sm text-gray-600 font-medium">with</span>
-            <span className="text-xs md:text-sm text-gray-600 font-medium">partners</span>
-            <span className="text-xs md:text-sm text-gray-600 font-medium">from</span>
+            <span className="text-xs md:text-sm text-gray-600 font-medium max-w-[6rem] leading-tight">
+              {caption}
+            </span>
           </div>
         </div>
         <div className="h-10 md:h-16 w-0.5 bg-gray-400"></div>
-        <InfiniteSlider
-          duration={55}
-          gap={32}
-          className="py-2 md:py-4 flex-1"
-        >
-        {logos.map((logo, index) => {
-          return (
+        <InfiniteSlider duration={55} gap={32} className="py-2 md:py-4 flex-1">
+          {logos.map((logo, index) => (
             <div
-              key={index}
+              key={`${logo.src}-${index}`}
               className="flex items-center justify-center h-10 md:h-16 w-auto relative"
             >
               <Image
@@ -57,8 +57,7 @@ export function LogoCarousel() {
                 sizes="(max-width: 768px) 200px, 400px"
               />
             </div>
-          );
-        })}
+          ))}
         </InfiniteSlider>
       </div>
     </div>

--- a/components/sales/cta-section.tsx
+++ b/components/sales/cta-section.tsx
@@ -3,27 +3,37 @@
 import { Button } from "@/components/ui/button"
 import { useLanguage } from "@/components/language-provider"
 import { salesDeck, pickLocale } from "@/lib/sales-deck"
+import { useSiteContent } from "@/lib/use-site-content"
 
 export function CtaSection() {
   const { language } = useLanguage()
-  const { cta } = salesDeck
+  const content = useSiteContent()
+  const override = content?.homepage?.cta
+
+  // Prefer admin-edited copy; fall back to the static sales deck until content
+  // loads (or if a field was left blank).
+  const title = override?.title?.[language] || override?.title?.en || pickLocale(salesDeck.cta.title, language)
+  const body = override?.body?.[language] || override?.body?.en || pickLocale(salesDeck.cta.body, language)
+  const buttonLabel =
+    override?.buttonLabel?.[language] || override?.buttonLabel?.en || pickLocale(salesDeck.cta.button, language)
+  const url = override?.url?.trim() || salesDeck.bookingUrl
 
   return (
     <section id="cta" className="bg-gray-950 py-24 md:py-32">
       <div className="container px-4 md:px-6 max-w-4xl text-center">
         <h2 className="text-4xl font-semibold md:text-5xl lg:text-6xl tracking-tight text-white mb-6">
-          {pickLocale(cta.title, language)}
+          {title}
         </h2>
         <p className="text-lg md:text-xl text-gray-300 mb-10 max-w-2xl mx-auto">
-          {pickLocale(cta.body, language)}
+          {body}
         </p>
         <Button
           size="lg"
           className="bg-primary hover:bg-primary/90 text-white text-base px-8 py-6 rounded-full shadow-lg hover:shadow-xl transition-all duration-200"
           asChild
         >
-          <a href={salesDeck.bookingUrl} target="_blank" rel="noopener noreferrer">
-            {pickLocale(cta.button, language)}
+          <a href={url} target="_blank" rel="noopener noreferrer">
+            {buttonLabel}
           </a>
         </Button>
       </div>

--- a/components/sales/proof-section.tsx
+++ b/components/sales/proof-section.tsx
@@ -1,12 +1,14 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useLanguage } from "@/components/language-provider"
 import { salesDeck, pickLocale } from "@/lib/sales-deck"
-import type { Locale } from "@/lib/site-content"
+import type { Locale, Localized } from "@/lib/site-content"
+import { useSiteContent } from "@/lib/use-site-content"
 import { OfferingArt } from "@/components/sales/offering-art"
 
 type Offering = (typeof salesDeck.proof.offerings)[number]
+type Metric = { label: Localized; value: Localized }
 
 /** How long each service holds before the desktop rail advances on its own. */
 const ROTATE_INTERVAL_MS = 6000
@@ -15,7 +17,18 @@ const ROTATE_INTERVAL_MS = 6000
 const DESKTOP_QUERY = "(min-width: 1024px)"
 
 /** Copy and illustration for one service — shared by the rail and the mobile panel. */
-function OfferingPanel({ offering, language }: { offering: Offering; language: Locale }) {
+function OfferingPanel({
+  offering,
+  language,
+  metrics,
+}: {
+  offering: Offering
+  language: Locale
+  // Admin-overridden stat figures for this service; falls back to the ones
+  // defined alongside the offering in lib/sales-deck.ts.
+  metrics?: Metric[]
+}) {
+  const shownMetrics = metrics ?? offering.metrics
   return (
     <div className="grid md:grid-cols-2 gap-8 lg:gap-12 items-center">
       <div>
@@ -26,7 +39,7 @@ function OfferingPanel({ offering, language }: { offering: Offering; language: L
           {pickLocale(offering.summary, language)}
         </p>
         <div className="mt-7 flex flex-wrap gap-x-10 gap-y-4">
-          {offering.metrics.map((metric, i) => (
+          {shownMetrics.map((metric, i) => (
             <div key={i}>
               <p className="text-xs text-muted-foreground mb-1.5">{pickLocale(metric.label, language)}</p>
               <p className="text-2xl md:text-3xl font-semibold text-primary tabular-nums leading-none">
@@ -67,6 +80,18 @@ function OfferingPanel({ offering, language }: { offering: Offering; language: L
 export function ProofSection() {
   const { language } = useLanguage()
   const { proof } = salesDeck
+  const content = useSiteContent()
+
+  // offeringId -> overridden metrics, from admin content. Offerings without an
+  // override (or overrides for offerings no longer in code) fall through to the
+  // static metrics.
+  const metricsById = useMemo(() => {
+    const map = new Map<string, Metric[]>()
+    for (const entry of content?.homepage?.proofMetrics ?? []) {
+      if (entry?.offeringId && Array.isArray(entry.metrics)) map.set(entry.offeringId, entry.metrics)
+    }
+    return map
+  }, [content])
   const [activeIndex, setActiveIndex] = useState(0)
   // Rotation is a hint for someone who has not engaged yet. The moment a
   // visitor picks a service it stops for good, so the panel never moves out
@@ -228,7 +253,7 @@ export function ProofSection() {
             aria-labelledby={`offering-tab-${active.id}`}
             className="min-w-0"
           >
-            <OfferingPanel offering={active} language={language} />
+            <OfferingPanel offering={active} language={language} metrics={metricsById.get(active.id)} />
           </div>
         </div>
       </div>
@@ -245,7 +270,7 @@ export function ProofSection() {
               <p className="mb-4 text-xs text-muted-foreground tabular-nums">
                 {index + 1} / {offerings.length}
               </p>
-              <OfferingPanel offering={offering} language={language} />
+              <OfferingPanel offering={offering} language={language} metrics={metricsById.get(offering.id)} />
             </div>
           </div>
         ))}

--- a/lib/site-content.ts
+++ b/lib/site-content.ts
@@ -87,6 +87,31 @@ export type SeoMetadata = {
   twitterCreator: string
 }
 
+export type HeroLogo = { name: string; src: string }
+
+/**
+ * Admin overrides for the two proof-section stat figures shown under each
+ * service. Keyed by the offering's code id — a service that no longer exists
+ * in code just has its override ignored, and a service with no override falls
+ * back to the metrics defined alongside it in lib/sales-deck.ts.
+ */
+export type ProofMetricOverride = {
+  offeringId: string
+  metrics: { label: Localized; value: Localized }[]
+}
+
+/**
+ * Editable homepage pieces that otherwise live hardcoded in components /
+ * lib/sales-deck.ts: the hero partner-logo carousel, the bottom call-to-action
+ * band, and the proof-section stat figures. Defaults mirror the current live
+ * values so an empty Blob renders identically to today.
+ */
+export type HomepageBlocks = {
+  heroLogos: { enabled: boolean; caption: Localized; items: HeroLogo[] }
+  cta: { title: Localized; body: Localized; buttonLabel: Localized; url: string }
+  proofMetrics: ProofMetricOverride[]
+}
+
 export const SECTION_KEYS = [
   "hero",
   "problem",
@@ -157,6 +182,7 @@ export type SiteContent = {
   about: { subtitle: Localized; sections: AboutSection[] }
   company: CompanyInfo
   seo: SeoMetadata
+  homepage: HomepageBlocks
 }
 
 const CONTENT_PATHNAME = "site-content/content.json"
@@ -540,6 +566,95 @@ export const defaultContent: SiteContent = {
       "Custom AI, apps, web, product development and software engineering. Your global technology partner.",
     twitterCreator: "@tecxmate",
   },
+  homepage: {
+    heroLogos: {
+      // Off by default: the carousel is currently not shown on the live hero.
+      // Turn it on in Admin → Homepage Blocks once the logos are set.
+      enabled: false,
+      caption: M("with partners from", "cùng đối tác từ", "合作夥伴來自"),
+      items: [
+        { name: "Crypted", src: "/logos/crypted.png" },
+        { name: "HealthMaxers", src: "/logos/healthmaxers.png" },
+        { name: "IPRP Shield", src: "/logos/IPRPSHIELD.png" },
+        { name: "CHI CHI Vietnamese", src: "/logos/chichi.png" },
+      ],
+    },
+    cta: {
+      title: M("The answer is here.", "Câu trả lời ở đây.", "答案就在這裡"),
+      body: M(
+        "A 30-minute Consultation gives you a clear read on what's possible.",
+        "Buổi tư vấn 30 phút giúp bạn thấy rõ những gì khả thi.",
+        "30 分鐘諮詢讓您清楚了解可行方案。",
+      ),
+      buttonLabel: M("Book a Consultation", "Đặt lịch tư vấn", "預約諮詢"),
+      url: "https://cal.com/nikolasdoan/30min",
+    },
+    proofMetrics: [
+      {
+        offeringId: "ai-agents",
+        metrics: [
+          { label: M("Runs on", "Chạy trên", "運行於"), value: M("Your documents", "Tài liệu của bạn", "您的文件") },
+          { label: M("Serves", "Phục vụ", "服務對象"), value: M("Staff & customers", "Nhân viên & khách hàng", "員工與客戶") },
+        ],
+      },
+      {
+        offeringId: "apps",
+        metrics: [
+          { label: M("MVP", "MVP", "MVP"), value: M("6 weeks", "6 tuần", "6 週") },
+          { label: M("Platforms", "Nền tảng", "平台"), value: M("iOS · Android · Web", "iOS · Android · Web", "iOS · Android · Web") },
+        ],
+      },
+      {
+        offeringId: "modernize",
+        metrics: [
+          { label: M("Office productivity", "Năng suất văn phòng", "辦公生產力"), value: M("+70–80%", "+70–80%", "+70–80%") },
+          { label: M("Auto-drafted", "Soạn tự động", "自動起草"), value: M("~90%", "~90%", "約 90%") },
+        ],
+      },
+      {
+        offeringId: "ai-seo",
+        metrics: [
+          { label: M("Optimized for", "Tối ưu cho", "優化對象"), value: M("ChatGPT · Gemini · Perplexity · Claude", "ChatGPT · Gemini · Perplexity · Claude", "ChatGPT · Gemini · Perplexity · Claude") },
+          { label: M("Reported", "Báo cáo", "回報"), value: M("Monthly", "Hằng tháng", "每月") },
+        ],
+      },
+      {
+        offeringId: "data",
+        metrics: [
+          { label: M("Delivered as", "Bàn giao dưới dạng", "交付格式"), value: M("Reports & dashboards", "Báo cáo & dashboard", "報告與儀表板") },
+          { label: M("You keep", "Bạn giữ", "歸您所有"), value: M("The data", "Toàn bộ dữ liệu", "全部資料") },
+        ],
+      },
+      {
+        offeringId: "ai-integration",
+        metrics: [
+          { label: M("Optimized for", "Tối ưu cho", "優化對象"), value: M("Your system", "Hệ thống của bạn", "您的系統") },
+          { label: M("First session", "Buổi đầu tiên", "首次課程"), value: M("Free", "Miễn phí", "免費") },
+        ],
+      },
+    ],
+  },
+}
+
+function mergeHomepage(stored?: Partial<HomepageBlocks>): HomepageBlocks {
+  const d = defaultContent.homepage
+  return {
+    heroLogos: {
+      enabled: stored?.heroLogos?.enabled ?? d.heroLogos.enabled,
+      caption: { ...d.heroLogos.caption, ...stored?.heroLogos?.caption },
+      // A stored array wins wholesale (the admin edits the full list); only
+      // fall back to defaults when nothing was ever saved.
+      items: stored?.heroLogos?.items ?? d.heroLogos.items,
+    },
+    cta: {
+      title: { ...d.cta.title, ...stored?.cta?.title },
+      body: { ...d.cta.body, ...stored?.cta?.body },
+      buttonLabel: { ...d.cta.buttonLabel, ...stored?.cta?.buttonLabel },
+      // Blank/missing URL falls back so an older blob can't produce a dead button.
+      url: stored?.cta?.url?.trim() || d.cta.url,
+    },
+    proofMetrics: stored?.proofMetrics ?? d.proofMetrics,
+  }
 }
 
 function mergeContent(stored?: Partial<SiteContent>): SiteContent {
@@ -578,6 +693,7 @@ function mergeContent(stored?: Partial<SiteContent>): SiteContent {
     ...defaultContent,
     ...stored,
     hero,
+    homepage: mergeHomepage(stored.homepage),
     company: {
       ...defaultContent.company,
       ...stored.company,

--- a/lib/use-site-content.ts
+++ b/lib/use-site-content.ts
@@ -1,0 +1,34 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import type { SiteContent } from "./site-content"
+
+// Module-level cache: every component that calls useSiteContent() during a
+// single page load shares ONE /api/content request rather than each firing
+// its own. Not refreshed within a session — a page reload picks up any admin
+// edits, which is all the homepage display needs.
+let cached: Promise<SiteContent | null> | null = null
+
+function loadSiteContent(): Promise<SiteContent | null> {
+  if (!cached) {
+    cached = fetch("/api/content", { cache: "no-store" })
+      .then((r) => (r.ok ? (r.json() as Promise<SiteContent>) : null))
+      .catch(() => null)
+  }
+  return cached
+}
+
+/** Returns the live site content once loaded, or null until then. */
+export function useSiteContent(): SiteContent | null {
+  const [content, setContent] = useState<SiteContent | null>(null)
+  useEffect(() => {
+    let active = true
+    loadSiteContent().then((c) => {
+      if (active) setContent(c)
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+  return content
+}


### PR DESCRIPTION
## Summary
The three homepage pieces you flagged are now editable from a new **Admin → Homepage Blocks** screen, following the same pattern as the existing content editors. Defaults mirror today's live values exactly, so nothing changes on deploy until someone edits them.

1. **Hero partner-logo carousel** — the logos were a hardcoded array, and the carousel was commented out of the hero entirely. Now driven by content: an editable name + image-path list plus a caption, gated on an **enabled** flag that defaults **OFF**. So the live hero looks identical (logos hidden) until you turn it on in admin. Re-enabled `<LogoCarousel/>` in the hero; it self-hides when off.
2. **Bottom call-to-action band** (separate from the hero button) — heading, body, button label, and button URL came straight from the static sales deck. Now prefers admin content, falling back to the deck.
3. **Proof-section stat figures** — the two figures under each service were hardcoded metrics. Now overridable per service (keyed by the offering's code id), with the service name/copy staying in code and only the numbers editable.

**Deliberately NOT included: the economics calculator's numbers.** Those are interactive parameters — segment multipliers and the `tecxmateRatio` that drives the "−X%" savings badge — not display copy. A wrong value there breaks the chart math, and they're not "change frequently" values, so they stay in code. (Everything else in the economics block is prose in the sales deck, not a figure.)

## Plumbing
- New `HomepageBlocks` type on `SiteContent`, with `mergeHomepage()` that deep-merges partial saves (a save touching only the CTA can't wipe the logos/metrics) and falls a blank URL back to the default.
- New shared `useSiteContent()` hook that dedupes the `/api/content` fetch to a **single request** across all three client components (rather than each firing its own).

## Test plan
- [x] `pnpm run build` — clean; new `/admin/homepage` route builds
- [x] `npx tsc --noEmit` — no new errors (3 pre-existing unrelated ones, none in touched files)
- [x] Live run: `/api/content` serves the new defaults (logos disabled, 4 logos, CTA with all 3 locales + URL, all 6 proof offerings' metrics); `/admin/homepage` and `/` both return 200
- [x] Homepage SSR still renders today's CTA heading and proof stat ("6 weeks") via fallback, and keeps the logos **hidden** (`crypted.png` absent) — confirming zero visual change until an admin opts in
- [x] Standalone test of merge-fallback semantics: partial save (only CTA) preserves logos + metrics; blank URL → default; empty content → all defaults
- [ ] Couldn't test end-to-end **persistence** (needs `BLOB_READ_WRITE_TOKEN`, not set in this sandbox) — the read/merge/render path is fully verified; the write path is the same plumbing the other editors already use. Worth one manual save-and-refresh after merge, especially toggling the logo carousel on.

## After merge
Everything's under **Admin → Homepage Blocks**, live within ~60s of saving, no redeploy. Turning the logo carousel on is now an admin action (it ships off, matching current behavior).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwF4AQSSx8TQ4M3PCs4Myq)_