### PR TITLE
Default the site theme to the device's system preference

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -146,7 +146,7 @@ export default function RootLayout({
           <FirebaseAnalytics />
           {/* Vercel Analytics is cookieless, so it needs no consent gate. */}
           <Analytics />
-          <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
+          <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
             <LanguageProvider>
               {children}
               <FloatingContact />

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -6,7 +6,12 @@ import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme()
+  // resolvedTheme is the theme actually applied — it collapses "system" to the
+  // concrete "light"/"dark" the device is currently showing. Keying the icon
+  // and the toggle direction off this (rather than `theme`, which is "system"
+  // until the visitor picks one) means the button reflects what's on screen
+  // and the first click flips to the opposite of what they actually see.
+  const { resolvedTheme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -22,14 +27,16 @@ export function ThemeToggle() {
     )
   }
 
+  const isDark = resolvedTheme === "dark"
+
   return (
     <Button
       variant="ghost"
       size="icon"
       className="h-9 w-9"
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
     >
-      {theme === "dark" ? (
+      {isDark ? (
         <Sun className="h-4 w-4 text-yellow-400" />
       ) : (
         <Moon className="h-4 w-4" />


### PR DESCRIPTION
## Summary
The site's theme now follows the visitor's **device system default** on first visit, instead of always starting in light mode.

- `ThemeProvider` was set to `defaultTheme="light"`, so every first-time visitor got light mode regardless of their OS being in dark mode. Changed to `defaultTheme="system"` (`enableSystem` was already on). A visitor with no saved preference now follows their OS light/dark setting; a manual toggle still stores and honors an explicit choice, exactly as before.
- Fixed the theme toggle to key off `resolvedTheme` instead of `theme`. Before a manual choice `theme` is `"system"`, so the old code showed the wrong icon — and flipped the wrong way on first click — when the system resolved to dark. `resolvedTheme` collapses `"system"` to the concrete light/dark actually on screen, so the icon matches what the visitor sees and the first click flips to the opposite.

No change to the `<html>` tag (already `suppressHydrationWarning`, no hardcoded theme class) or `color-scheme: light dark` metadata — those were already correct.

## Test plan
- [x] `pnpm run build` — clean
- [x] `npx tsc --noEmit` — no new errors (3 pre-existing unrelated)
- [x] Real browser (Playwright, emulating OS `colorScheme`): first visit with **OS=dark applies dark**, **OS=light applies light** — theme follows the system default
- [x] Manual toggle from a dark system flips to light and **persists** the choice to `localStorage` (system default only applies until the visitor picks one)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwF4AQSSx8TQ4M3PCs4Myq)_